### PR TITLE
perf(map): map-pan phase 1 — eliminate gesture stalls

### DIFF
--- a/client/src/components/CityPopup/CityPopup.tsx
+++ b/client/src/components/CityPopup/CityPopup.tsx
@@ -1,6 +1,6 @@
-import { ActionIcon, useMantineColorScheme } from '@mantine/core';
+import { ActionIcon, Text, useMantineColorScheme } from '@mantine/core';
 import { useMemo, useState } from 'react';
-import { IconX } from '@tabler/icons-react';
+import { IconAlertCircle, IconX } from '@tabler/icons-react';
 
 import useWeatherDataForCity from '@/api/dates/useWeatherDataForCity';
 import useSunshineDataForCity from '@/api/dates/useSunshineDataForCity';
@@ -11,6 +11,7 @@ import RibbonShell from '@/components/CityPopup/Ribbon/RibbonShell';
 import { useRibbonStats } from '@/components/CityPopup/hooks/useRibbonStats';
 import { toTitleCase } from '@/utils/dataFormatting/toTitleCase';
 import { getSunshinePercent } from '@/utils/dataFormatting/getSunshinePercent';
+import { hasSunshineData } from '@/utils/dataFormatting/hasSunshineData';
 import { normalizeRainyDays } from '@/utils/dataFormatting/normalizeRainyDays';
 import { normalizeWeekPrecip } from '@/utils/dataFormatting/normalizeWeekPrecip';
 import { dateToWeekOfYear } from '@/utils/dateFormatting/dateToWeekOfYear';
@@ -123,6 +124,37 @@ const CityPopup = ({
   }, [weatherData, cityAsWeather, dataType]);
 
   const displaySunshineData = cityAsSunshine ?? sunshineData;
+
+  const primaryHasSunshine = hasSunshineData(displaySunshineData);
+  const comparisonHasSunshine = hasSunshineData(comparisonSunshineData);
+
+  // While sunshine is loading we keep the tab present so the user sees the
+  // loader rather than a tab popping in/out.
+  const sunshineTabAvailable =
+    sunshineLoading || primaryHasSunshine || comparisonHasSunshine;
+
+  const availableTabs = useMemo<ReadonlyArray<DataType>>(
+    () =>
+      sunshineTabAvailable
+        ? [DataType.Temperature, DataType.Sunshine, DataType.Precip]
+        : [DataType.Temperature, DataType.Precip],
+    [sunshineTabAvailable]
+  );
+
+  const notesByTab = useMemo(
+    () => ({
+      [DataType.Sunshine]:
+        !primaryHasSunshine && comparisonHasSunshine ? (
+          <div className='flex gap-1 mr-4 items-center'>
+            <IconAlertCircle size={15} color={appColors.error}/>
+            <Text fz='sm' fs='italic' c="dimmed">
+              No sunshine data for {toTitleCase(city?.city ?? '')}
+            </Text>
+          </div>
+        ) : null,
+    }),
+    [primaryHasSunshine, comparisonHasSunshine, city?.city]
+  );
 
   const excludeCity = useMemo(
     () =>
@@ -237,6 +269,8 @@ const CityPopup = ({
         todayValuesByTab={todayValuesByTab}
         selectedDate={dateToUse}
         stats={stats}
+        availableTabs={availableTabs}
+        notesByTab={notesByTab}
         comparisonNode={
           <ComparisonCitySelector
             onCitySelect={setComparisonCity}

--- a/client/src/components/CityPopup/CityPopup.tsx
+++ b/client/src/components/CityPopup/CityPopup.tsx
@@ -145,9 +145,9 @@ const CityPopup = ({
     () => ({
       [DataType.Sunshine]:
         !primaryHasSunshine && comparisonHasSunshine ? (
-          <div className='flex gap-1 mr-4 items-center'>
-            <IconAlertCircle size={15} color={appColors.error}/>
-            <Text fz='sm' fs='italic' c="dimmed">
+          <div className="flex gap-1 mr-4 items-center">
+            <IconAlertCircle size={15} color={appColors.error} />
+            <Text fz="sm" fs="italic" c="dimmed">
               No sunshine data for {toTitleCase(city?.city ?? '')}
             </Text>
           </div>

--- a/client/src/components/CityPopup/Ribbon/IconTabs.tsx
+++ b/client/src/components/CityPopup/Ribbon/IconTabs.tsx
@@ -6,6 +6,7 @@ import { CITY1_PRIMARY_COLOR } from '@/const';
 interface IconTabsProps {
   tab: DataType;
   onTab: (next: DataType) => void;
+  availableTabs?: ReadonlyArray<DataType>;
 }
 
 interface TabItem {
@@ -24,10 +25,13 @@ const TABS: ReadonlyArray<TabItem> = [
   { id: DataType.Precip, label: 'Precip', icon: <IconDroplet size={16} /> },
 ];
 
-const IconTabs = ({ tab, onTab }: IconTabsProps) => {
+const IconTabs = ({ tab, onTab, availableTabs }: IconTabsProps) => {
+  const visible = availableTabs
+    ? TABS.filter((t) => availableTabs.includes(t.id))
+    : TABS;
   return (
     <div className="flex gap-1">
-      {TABS.map((t) => {
+      {visible.map((t) => {
         const active = t.id === tab;
         return (
           <button

--- a/client/src/components/CityPopup/Ribbon/RibbonShell.tsx
+++ b/client/src/components/CityPopup/Ribbon/RibbonShell.tsx
@@ -5,7 +5,7 @@ import type {
   TodayValuesByTab,
 } from '@/types/cityPopupTypes';
 import type { SearchCitiesResult } from '@/types/userLocationType';
-import type { DataType } from '@/types/mapTypes';
+import { DataType } from '@/types/mapTypes';
 import { RIBBON_HEADER_RIGHT_RESERVE_PX } from '@/const';
 import CityNamesHeader from './CityNamesHeader';
 import TodayReadout from './TodayReadout';
@@ -22,6 +22,8 @@ interface RibbonShellProps {
   selectedDate: string;
   stats: ReadonlyArray<RibbonStat>;
   comparisonNode?: ReactNode;
+  availableTabs?: ReadonlyArray<DataType>;
+  notesByTab?: Partial<Record<DataType, ReactNode>>;
   renderChart: (
     tab: DataType,
     onHover: (payload: RibbonHoverPayload | null) => void
@@ -37,10 +39,20 @@ const RibbonShell = ({
   selectedDate,
   stats,
   comparisonNode,
+  availableTabs,
+  notesByTab,
   renderChart,
 }: RibbonShellProps) => {
   const [tab, setTab] = useState<DataType>(initialTab);
   const [hover, setHover] = useState<RibbonHoverPayload | null>(null);
+
+  // If the user's intent tab disappeared (e.g. comparison city removed and it
+  // was the only city with sunshine), fall back to the first available tab.
+  // The intent stays in `tab` so it returns when the data comes back.
+  const visibleTab =
+    availableTabs && !availableTabs.includes(tab)
+      ? (availableTabs[0] ?? DataType.Temperature)
+      : tab;
 
   const hasComparison = !!comparisonCity;
   const {
@@ -48,7 +60,9 @@ const RibbonShell = ({
     c2: todayC2,
     subC1: todaySubC1,
     subC2: todaySubC2,
-  } = todayValuesByTab[tab];
+  } = todayValuesByTab[visibleTab];
+
+  const footerNote = notesByTab?.[visibleTab] ?? null;
 
   const handleHover = useCallback((payload: RibbonHoverPayload | null) => {
     setHover(payload);
@@ -67,7 +81,7 @@ const RibbonShell = ({
             comparisonNode={comparisonNode}
           />
           <TodayReadout
-            tab={tab}
+            tab={visibleTab}
             c1Value={todayC1}
             c2Value={todayC2}
             subC1Value={todaySubC1 ?? null}
@@ -78,12 +92,19 @@ const RibbonShell = ({
           />
         </header>
 
-        <main className="flex-1 min-h-0">{renderChart(tab, handleHover)}</main>
+        <main className="flex-1 min-h-0">
+          {renderChart(visibleTab, handleHover)}
+        </main>
 
         <MonthLabels />
 
-        <footer className="mt-2">
-          <IconTabs tab={tab} onTab={setTab} />
+        <footer className="mt-2 flex items-center justify-between gap-3">
+          <IconTabs
+            tab={visibleTab}
+            onTab={setTab}
+            availableTabs={availableTabs}
+          />
+          {footerNote}
         </footer>
       </div>
 

--- a/client/src/components/CityPopup/SunshineDataSection.tsx
+++ b/client/src/components/CityPopup/SunshineDataSection.tsx
@@ -29,8 +29,7 @@ const SunshineDataSection = ({
       isLoading={isLoading}
       hasError={hasError}
       errorMessage="Failed to load sunshine data for this city."
-      showNoDataBadge={true}
-      noDataMessage="No sunshine data available"
+      showNoDataBadge={false}
     >
       {(data) => (
         <ComponentErrorBoundary componentName="SunshineGraph">

--- a/client/src/components/Map/MapDataLoader.tsx
+++ b/client/src/components/Map/MapDataLoader.tsx
@@ -3,6 +3,7 @@ import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useSunshineStore } from '@/stores/useSunshineStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { DataType } from '@/types/mapTypes';
+import { MAP_DATA_LOADER_FADE_MS } from '@/const';
 
 interface MapDataLoaderProps {
   dataType: DataType;
@@ -15,16 +16,22 @@ const MapDataLoader = ({ dataType }: MapDataLoaderProps) => {
   const isLoading =
     dataType === DataType.Sunshine ? isLoadingSunshine : isLoadingWeather;
 
-  // Show during the whole pan→data-flush window: while the user is actively
-  // gesturing, while the bounds query is in flight, AND while the post-load
-  // gesture grace is still gating the marker flush.
+  // Visible during the whole pan→flush window: gesturing, bounds query
+  // in flight, or the post-load gesture grace still gating the flush.
   const visible = isGesturing || isLoading;
 
   return (
-    <Transition mounted={visible} transition="fade" duration={150}>
+    <Transition
+      mounted={visible}
+      transition="fade"
+      duration={MAP_DATA_LOADER_FADE_MS}
+    >
       {(styles) => (
         <div
           style={styles}
+          role="status"
+          aria-live="polite"
+          aria-label="Loading map data"
           className="absolute top-4 right-4 z-30 pointer-events-none"
         >
           <Loader size="sm" />

--- a/client/src/components/Map/MapDataLoader.tsx
+++ b/client/src/components/Map/MapDataLoader.tsx
@@ -1,6 +1,7 @@
 import { Loader, Transition } from '@mantine/core';
 import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useSunshineStore } from '@/stores/useSunshineStore';
+import { useAppStore } from '@/stores/useAppStore';
 import { DataType } from '@/types/mapTypes';
 
 interface MapDataLoaderProps {
@@ -10,11 +11,17 @@ interface MapDataLoaderProps {
 const MapDataLoader = ({ dataType }: MapDataLoaderProps) => {
   const isLoadingWeather = useWeatherStore((s) => s.isLoadingWeather);
   const isLoadingSunshine = useSunshineStore((s) => s.isLoadingSunshine);
+  const isGesturing = useAppStore((s) => s.isGesturing);
   const isLoading =
     dataType === DataType.Sunshine ? isLoadingSunshine : isLoadingWeather;
 
+  // Show during the whole pan→data-flush window: while the user is actively
+  // gesturing, while the bounds query is in flight, AND while the post-load
+  // gesture grace is still gating the marker flush.
+  const visible = isGesturing || isLoading;
+
   return (
-    <Transition mounted={isLoading} transition="fade" duration={150}>
+    <Transition mounted={visible} transition="fade" duration={150}>
       {(styles) => (
         <div
           style={styles}

--- a/client/src/components/Map/MapDataLoader.tsx
+++ b/client/src/components/Map/MapDataLoader.tsx
@@ -1,0 +1,30 @@
+import { Loader, Transition } from '@mantine/core';
+import { useWeatherStore } from '@/stores/useWeatherStore';
+import { useSunshineStore } from '@/stores/useSunshineStore';
+import { DataType } from '@/types/mapTypes';
+
+interface MapDataLoaderProps {
+  dataType: DataType;
+}
+
+const MapDataLoader = ({ dataType }: MapDataLoaderProps) => {
+  const isLoadingWeather = useWeatherStore((s) => s.isLoadingWeather);
+  const isLoadingSunshine = useSunshineStore((s) => s.isLoadingSunshine);
+  const isLoading =
+    dataType === DataType.Sunshine ? isLoadingSunshine : isLoadingWeather;
+
+  return (
+    <Transition mounted={isLoading} transition="fade" duration={150}>
+      {(styles) => (
+        <div
+          style={styles}
+          className="absolute top-4 right-4 z-30 pointer-events-none"
+        >
+          <Loader size="sm" />
+        </div>
+      )}
+    </Transition>
+  );
+};
+
+export default MapDataLoader;

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -15,6 +15,7 @@ import {
   MAP_FADE_IN_DELAY_MS,
   MAP_LOADED_OPACITY,
   MAP_LOADING_OPACITY,
+  MAP_MAX_DEVICE_PIXEL_RATIO,
   MAP_SCROLL_ZOOM_SPEED,
   MAP_STYLES,
 } from '@/const';
@@ -229,6 +230,10 @@ const WorldMap = ({
           getTooltip={() => null}
           getCursor={getCursor}
           style={deckGLStyle}
+          useDevicePixels={Math.min(
+            window.devicePixelRatio,
+            MAP_MAX_DEVICE_PIXEL_RATIO
+          )}
         >
           <Map
             mapStyle={MAP_STYLES[colorScheme]}

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -24,6 +24,7 @@ import MapTooltip from './MapTooltip';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useSunshineStore } from '@/stores/useSunshineStore';
+import { useAppStore } from '@/stores/useAppStore';
 import { DataType } from '@/types/mapTypes';
 import type { ViewMode, WeatherDataUnion } from '@/types/mapTypes';
 import { perfMonitor } from '@/utils/performance/performanceMonitor';
@@ -73,6 +74,7 @@ const WorldMap = ({
   const isLoadingSunshine = useSunshineStore(
     (state) => state.isLoadingSunshine
   );
+  const isGesturing = useAppStore((state) => state.isGesturing);
   const { viewState, onViewStateChange } = useMapBounds(
     INITIAL_VIEW_STATE,
     onBoundsChange
@@ -94,9 +96,15 @@ const WorldMap = ({
     isBasemapLoaded,
   });
 
-  // Breathe animation — only active during Tier 2 (pan/zoom) loads
+  // Breathe animation + ghost dots only fire during tier2 AND only while
+  // the user isn't actively gesturing. The MapDataLoader spinner is the
+  // single source of "loading is happening" feedback during a pan; both
+  // the breathe pulse and the placeholder ghost-dot grid are visual noise
+  // that competes with the (gated) real markers and adds GPU work.
+  const showLoadingDecorations = tier === 'tier2' && !isGesturing;
+
   const { opacity: breatheOpacity } = useBreatheAnimation({
-    isActive: tier === 'tier2',
+    isActive: showLoadingDecorations,
   });
 
   // Get city layers (heatmap + markers) - these are expensive to recreate
@@ -105,8 +113,8 @@ const WorldMap = ({
     viewMode,
     dataType,
     selectedMonth,
-    breatheOpacity: tier === 'tier2' ? breatheOpacity : undefined,
-    isGhostDotsActive: tier === 'tier2',
+    breatheOpacity: showLoadingDecorations ? breatheOpacity : undefined,
+    isGhostDotsActive: showLoadingDecorations,
     viewState,
   });
 

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -254,7 +254,7 @@ const WorldMap = ({
         {(transitionStyle) => (
           <div
             style={transitionStyle}
-            className="absolute inset-0 flex items-center justify-center bg-background/70 backdrop-blur-sm z-10"
+            className="absolute inset-0 flex items-center justify-center bg-background/70 backdrop-blur-sm z-10 pointer-events-none"
           >
             <Loader size="lg" />
           </div>

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -15,8 +15,8 @@ import {
   MAP_FADE_IN_DELAY_MS,
   MAP_LOADED_OPACITY,
   MAP_LOADING_OPACITY,
+  MAP_SCROLL_ZOOM_SPEED,
   MAP_STYLES,
-  ZOOM_AMPLIFICATION_FACTOR,
 } from '@/const';
 import CityPopup from '../CityPopup/CityPopup';
 import MapTooltip from './MapTooltip';
@@ -145,7 +145,7 @@ const WorldMap = ({
     () => ({
       dragPan: true,
       dragRotate: false,
-      scrollZoom: { speed: ZOOM_AMPLIFICATION_FACTOR / 10 },
+      scrollZoom: { speed: MAP_SCROLL_ZOOM_SPEED, smooth: true },
       touchZoom: true,
       touchRotate: false,
       keyboard: true,

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -145,7 +145,7 @@ const WorldMap = ({
     () => ({
       dragPan: true,
       dragRotate: false,
-      scrollZoom: { speed: MAP_SCROLL_ZOOM_SPEED, smooth: true },
+      scrollZoom: { speed: MAP_SCROLL_ZOOM_SPEED },
       touchZoom: true,
       touchRotate: false,
       keyboard: true,

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -26,6 +26,11 @@ export const BOUNDS_BUFFER_PERCENT = 0.3; // add 30% buffer to viewport bounds t
 // more responsive feel without the overshoot the previous 15× value caused.
 export const MAP_SCROLL_ZOOM_SPEED = 0.03;
 
+// Cap deck.gl's drawing-buffer ratio at 1.5×. On 2× and 3× displays the
+// default (full devicePixelRatio) makes the GPU rasterise 4× / 9× more
+// fragments per frame; the visual diff at marker scales is imperceptible.
+export const MAP_MAX_DEVICE_PIXEL_RATIO = 1.5;
+
 // initial map view state
 export const INITIAL_VIEW_STATE = {
   longitude: 0,

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -21,7 +21,10 @@ export const CITY_CACHE_MAX_SIZE = 30;
 export const ZOOM_THRESHOLD = 2; // switch to bounds query at zoom level 2+ (continental view)
 export const DEBOUNCE_DELAY = 200; // ms - debounce delay for zoom/pan events (reduced for more responsive feel)
 export const BOUNDS_BUFFER_PERCENT = 0.3; // add 30% buffer to viewport bounds to pre-fetch dots before they're visible
-export const ZOOM_AMPLIFICATION_FACTOR = 1.5; // amplify zoom changes for more sensitive pinch/scroll zoom
+
+// deck.gl scrollZoom speed. Default is 0.01; we use 3× default for a slightly
+// more responsive feel without the overshoot the previous 15× value caused.
+export const MAP_SCROLL_ZOOM_SPEED = 0.03;
 
 // initial map view state
 export const INITIAL_VIEW_STATE = {

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -25,7 +25,7 @@ export const DEBOUNCE_DELAY = 300; // ms — bounds-query debounce: how long the
 // than DEBOUNCE_DELAY on purpose: even after the bounds query fires and
 // data lands, we want to keep gating layer flushes for a bit so a quick
 // follow-up pan isn't blocked by the post-load 80 ms transition.
-export const GESTURE_GRACE_MS = 700;
+export const GESTURE_GRACE_MS = 800;
 export const BOUNDS_BUFFER_PERCENT = 0.3; // add 30% buffer to viewport bounds to pre-fetch dots before they're visible
 
 // deck.gl scrollZoom speed. Default is 0.01; we use 3× default for a slightly

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -31,6 +31,15 @@ export const MAP_SCROLL_ZOOM_SPEED = 0.03;
 // fragments per frame; the visual diff at marker scales is imperceptible.
 export const MAP_MAX_DEVICE_PIXEL_RATIO = 1.5;
 
+// Marker transition durations (ms). Previously 400-600 ms, which meant
+// every layer rebuild kicked off ~600 ms of GPU-bound color/opacity/radius
+// animations on 300 markers — and any pan gesture started during that
+// window stalled. 80 ms still reads as an intentional fade-in but doesn't
+// hold the next gesture hostage.
+export const MARKER_COLOR_TRANSITION_MS = 80;
+export const MARKER_OPACITY_TRANSITION_MS = 80;
+export const MARKER_RADIUS_TRANSITION_MS = 80;
+
 // initial map view state
 export const INITIAL_VIEW_STATE = {
   longitude: 0,

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -19,7 +19,13 @@ export const CITY_CACHE_MAX_SIZE = 30;
 
 // zoom-based loading thresholds
 export const ZOOM_THRESHOLD = 2; // switch to bounds query at zoom level 2+ (continental view)
-export const DEBOUNCE_DELAY = 200; // ms - debounce delay for zoom/pan events (reduced for more responsive feel)
+export const DEBOUNCE_DELAY = 300; // ms — bounds-query debounce: how long the viewport must be idle before we fire a new bounds query
+
+// How long isGesturing stays true after the last viewState change. Longer
+// than DEBOUNCE_DELAY on purpose: even after the bounds query fires and
+// data lands, we want to keep gating layer flushes for a bit so a quick
+// follow-up pan isn't blocked by the post-load 80 ms transition.
+export const GESTURE_GRACE_MS = 700;
 export const BOUNDS_BUFFER_PERCENT = 0.3; // add 30% buffer to viewport bounds to pre-fetch dots before they're visible
 
 // deck.gl scrollZoom speed. Default is 0.01; we use 3× default for a slightly

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -21,30 +21,27 @@ export const CITY_CACHE_MAX_SIZE = 30;
 export const ZOOM_THRESHOLD = 2; // switch to bounds query at zoom level 2+ (continental view)
 export const DEBOUNCE_DELAY = 300; // ms — bounds-query debounce: how long the viewport must be idle before we fire a new bounds query
 
-// How long isGesturing stays true after the last viewState change. Longer
-// than DEBOUNCE_DELAY on purpose: even after the bounds query fires and
-// data lands, we want to keep gating layer flushes for a bit so a quick
-// follow-up pan isn't blocked by the post-load 80 ms transition.
+// Holds isGesturing true after the last viewState change. Longer than
+// DEBOUNCE_DELAY so a quick follow-up pan isn't blocked by the post-load transition.
 export const GESTURE_GRACE_MS = 800;
 export const BOUNDS_BUFFER_PERCENT = 0.3; // add 30% buffer to viewport bounds to pre-fetch dots before they're visible
 
-// deck.gl scrollZoom speed. Default is 0.01; we use 3× default for a slightly
-// more responsive feel without the overshoot the previous 15× value caused.
+// deck.gl scrollZoom speed. 3× default (0.01) for responsiveness without
+// the overshoot the previous 15× value caused.
 export const MAP_SCROLL_ZOOM_SPEED = 0.03;
 
-// Cap deck.gl's drawing-buffer ratio at 1.5×. On 2× and 3× displays the
-// default (full devicePixelRatio) makes the GPU rasterise 4× / 9× more
-// fragments per frame; the visual diff at marker scales is imperceptible.
+// Cap deck.gl drawing-buffer ratio. Full devicePixelRatio on 2×/3× displays
+// rasterises 4×/9× more fragments per frame for an imperceptible visual gain.
 export const MAP_MAX_DEVICE_PIXEL_RATIO = 1.5;
 
-// Marker transition durations (ms). Previously 400-600 ms, which meant
-// every layer rebuild kicked off ~600 ms of GPU-bound color/opacity/radius
-// animations on 300 markers — and any pan gesture started during that
-// window stalled. 80 ms still reads as an intentional fade-in but doesn't
-// hold the next gesture hostage.
+// Marker fade-in durations (ms). Long transitions on 300 markers stalled
+// gestures started during the layer rebuild; 80 ms still reads intentional.
 export const MARKER_COLOR_TRANSITION_MS = 80;
 export const MARKER_OPACITY_TRANSITION_MS = 80;
 export const MARKER_RADIUS_TRANSITION_MS = 80;
+
+// Mantine Transition duration (ms) for the small map data-loading spinner.
+export const MAP_DATA_LOADER_FADE_MS = 150;
 
 // initial map view state
 export const INITIAL_VIEW_STATE = {

--- a/client/src/hooks/useMapBounds.ts
+++ b/client/src/hooks/useMapBounds.ts
@@ -66,6 +66,7 @@ export const useMapBounds = (
   // subscribing to it is fine.
   const initialMapViewportRef = useRef(useAppStore.getState().mapViewport);
   const setMapViewport = useAppStore((state) => state.setMapViewport);
+  const setIsGesturing = useAppStore((state) => state.setIsGesturing);
 
   const [viewState, setViewState] = useState<MapViewState>(
     initialMapViewportRef.current
@@ -79,7 +80,7 @@ export const useMapBounds = (
   );
   const [bounds, setBounds] = useState<MapBounds | null>(null);
   const [shouldUseBounds, setShouldUseBounds] = useState(false);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onViewStateChange = useCallback(
     ({ viewState: newViewState }: { viewState: MapViewState }) => {
@@ -104,6 +105,10 @@ export const useMapBounds = (
         zoom: newViewState.zoom,
       });
 
+      // Mark a gesture as active. Repeated true→true sets are deduped at the
+      // selector level so map.tsx doesn't re-render on every frame.
+      setIsGesturing(true);
+
       // clear existing debounce timer
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
@@ -111,6 +116,10 @@ export const useMapBounds = (
 
       // debounce bounds calculation and query trigger
       debounceTimerRef.current = setTimeout(() => {
+        // Gesture has been idle for DEBOUNCE_DELAY — flush deferred data and
+        // fire the bounds query.
+        setIsGesturing(false);
+
         const useBounds = newViewState.zoom >= ZOOM_THRESHOLD;
         setShouldUseBounds(useBounds);
 
@@ -124,7 +133,7 @@ export const useMapBounds = (
         }
       }, DEBOUNCE_DELAY);
     },
-    [onBoundsChange, setMapViewport]
+    [onBoundsChange, setMapViewport, setIsGesturing]
   );
 
   // cleanup debounce timer on unmount

--- a/client/src/hooks/useMapBounds.ts
+++ b/client/src/hooks/useMapBounds.ts
@@ -1,7 +1,12 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { MapViewState, ViewStateChangeParameters } from '@deck.gl/core';
 import { WebMercatorViewport } from '@deck.gl/core';
-import { ZOOM_THRESHOLD, DEBOUNCE_DELAY, BOUNDS_BUFFER_PERCENT } from '@/const';
+import {
+  ZOOM_THRESHOLD,
+  DEBOUNCE_DELAY,
+  BOUNDS_BUFFER_PERCENT,
+  GESTURE_GRACE_MS,
+} from '@/const';
 import { useAppStore } from '@/stores/useAppStore';
 import type { MapBounds } from '@/types/mapTypes';
 
@@ -80,7 +85,16 @@ export const useMapBounds = (
   );
   const [bounds, setBounds] = useState<MapBounds | null>(null);
   const [shouldUseBounds, setShouldUseBounds] = useState(false);
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Two separate timers so the bounds query can fire promptly (DEBOUNCE_DELAY)
+  // while the gesture flag stays held longer (GESTURE_GRACE_MS) — that grace
+  // window absorbs rapid pan-pause-pan sequences whose gap would otherwise
+  // straddle the query-firing moment and let a layer flush land mid-stream.
+  const boundsQueryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const gestureGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   const onViewStateChange = useCallback(
     ({ viewState: newViewState }: { viewState: MapViewState }) => {
@@ -109,17 +123,11 @@ export const useMapBounds = (
       // selector level so map.tsx doesn't re-render on every frame.
       setIsGesturing(true);
 
-      // clear existing debounce timer
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
+      // (Re)arm the bounds-query timer.
+      if (boundsQueryTimerRef.current) {
+        clearTimeout(boundsQueryTimerRef.current);
       }
-
-      // debounce bounds calculation and query trigger
-      debounceTimerRef.current = setTimeout(() => {
-        // Gesture has been idle for DEBOUNCE_DELAY — flush deferred data and
-        // fire the bounds query.
-        setIsGesturing(false);
-
+      boundsQueryTimerRef.current = setTimeout(() => {
         const useBounds = newViewState.zoom >= ZOOM_THRESHOLD;
         setShouldUseBounds(useBounds);
 
@@ -132,15 +140,26 @@ export const useMapBounds = (
           onBoundsChange?.(null, false);
         }
       }, DEBOUNCE_DELAY);
+
+      // (Re)arm the gesture-flag timer with a longer grace window.
+      if (gestureGraceTimerRef.current) {
+        clearTimeout(gestureGraceTimerRef.current);
+      }
+      gestureGraceTimerRef.current = setTimeout(() => {
+        setIsGesturing(false);
+      }, GESTURE_GRACE_MS);
     },
     [onBoundsChange, setMapViewport, setIsGesturing]
   );
 
-  // cleanup debounce timer on unmount
+  // cleanup timers on unmount
   useEffect(() => {
     return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
+      if (boundsQueryTimerRef.current) {
+        clearTimeout(boundsQueryTimerRef.current);
+      }
+      if (gestureGraceTimerRef.current) {
+        clearTimeout(gestureGraceTimerRef.current);
       }
     };
   }, []);

--- a/client/src/hooks/useMapBounds.ts
+++ b/client/src/hooks/useMapBounds.ts
@@ -59,17 +59,21 @@ export const useMapBounds = (
   initialViewState: MapViewState,
   onBoundsChange?: (bounds: MapBounds | null, shouldUseBounds: boolean) => void
 ): UseMapBoundsReturn => {
-  const mapViewport = useAppStore((state) => state.mapViewport);
+  // Read mapViewport once at mount via getState() instead of subscribing —
+  // this hook also writes to mapViewport on every onViewStateChange (~60/sec
+  // during a pan), and a selector subscription would cause WorldMap to
+  // re-render on every write. The setter is a stable Zustand reference so
+  // subscribing to it is fine.
+  const initialMapViewportRef = useRef(useAppStore.getState().mapViewport);
   const setMapViewport = useAppStore((state) => state.setMapViewport);
 
-  // use stored viewport if available, otherwise use initial view state
   const [viewState, setViewState] = useState<MapViewState>(
-    mapViewport
+    initialMapViewportRef.current
       ? {
           ...initialViewState,
-          latitude: mapViewport.latitude,
-          longitude: mapViewport.longitude,
-          zoom: mapViewport.zoom,
+          latitude: initialMapViewportRef.current.latitude,
+          longitude: initialMapViewportRef.current.longitude,
+          zoom: initialMapViewportRef.current.zoom,
         }
       : initialViewState
   );

--- a/client/src/hooks/useMapLayers.ts
+++ b/client/src/hooks/useMapLayers.ts
@@ -18,6 +18,9 @@ import {
   TEMPERATURE_LOADING_COLOR,
   GHOST_DOT_OPACITY,
   INITIAL_VIEW_STATE,
+  MARKER_COLOR_TRANSITION_MS,
+  MARKER_OPACITY_TRANSITION_MS,
+  MARKER_RADIUS_TRANSITION_MS,
 } from '@/const';
 import { useGhostDots, type GhostDot } from './useGhostDots';
 import { useWeatherStore } from '@/stores/useWeatherStore';
@@ -205,15 +208,15 @@ function useMapLayers({
           lineWidthMaxPixels: 1.5,
           transitions: {
             getFillColor: {
-              duration: 600,
+              duration: MARKER_COLOR_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
             },
             opacity: {
-              duration: 550,
+              duration: MARKER_OPACITY_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
             },
             getRadius: {
-              duration: 400,
+              duration: MARKER_RADIUS_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
               enter: () => [0],
             },
@@ -248,15 +251,15 @@ function useMapLayers({
           lineWidthMaxPixels: 1.5,
           transitions: {
             getFillColor: {
-              duration: 600,
+              duration: MARKER_COLOR_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
             },
             opacity: {
-              duration: 550,
+              duration: MARKER_OPACITY_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
             },
             getRadius: {
-              duration: 400,
+              duration: MARKER_RADIUS_TRANSITION_MS,
               easing: (t: number) => t * (2 - t),
               enter: () => [0],
             },

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -89,6 +89,7 @@ const MapPage: FC = () => {
   );
   const temperatureUnit = useAppStore((state) => state.temperatureUnit);
   const setTemperatureUnit = useAppStore((state) => state.setTemperatureUnit);
+  const isGesturing = useAppStore((state) => state.isGesturing);
 
   // Get the appropriate data based on the selected data type
   const displayedData = isSunshineSelected
@@ -100,20 +101,24 @@ const MapPage: FC = () => {
     setSearchParams({ date: selectedDate }, { replace: true });
   }, [selectedDate, setSearchParams]);
 
-  // update store when data changes based on selected data type
-  // consolidate multi-station cities to prevent duplicate markers
+  // update store when data changes based on selected data type. Loading
+  // flags pass through unconditionally so tier detection stays accurate;
+  // the displayed-data writes are deferred while a pan/zoom gesture is
+  // active so the layer rebuild + transition can't stall the next frame.
+  // When isGesturing flips back to false this effect re-runs and the
+  // pending data flushes in a single shot.
   useEffect(() => {
     if (isSunshineSelected) {
       setIsLoadingSunshine(isSunshineLoading);
 
-      if (sunshineData && !isSunshineLoading) {
+      if (sunshineData && !isSunshineLoading && !isGesturing) {
         const consolidated = consolidateSunshineByCity(sunshineData);
         setDisplayedSunshineData(consolidated);
       }
     } else {
       setIsLoadingWeather(isLoading);
 
-      if (weatherData && !isLoading) {
+      if (weatherData && !isLoading && !isGesturing) {
         const consolidated = consolidateWeatherByCity(weatherData);
         setDisplayedWeatherData(consolidated);
       }
@@ -124,6 +129,7 @@ const MapPage: FC = () => {
     isLoading,
     isSunshineLoading,
     isSunshineSelected,
+    isGesturing,
     setDisplayedWeatherData,
     setDisplayedSunshineData,
     setIsLoadingWeather,

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -16,6 +16,7 @@ import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
 import { INITIAL_VIEW_STATE, ZOOM_THRESHOLD } from '@/const';
 import ComponentErrorBoundary from '../components/ErrorBoundary/ComponentErrorBoundary';
 import MapColorLegend from '../components/Map/MapColorLegend';
+import MapDataLoader from '../components/Map/MapDataLoader';
 import { consolidateWeatherByCity } from '@/utils/data/consolidateWeatherByCity';
 import { consolidateSunshineByCity } from '@/utils/data/consolidateSunshineByCity';
 
@@ -165,6 +166,8 @@ const MapPage: FC = () => {
       <div className="absolute top-4 left-4 z-20">
         <MapColorLegend dataType={dataType} />
       </div>
+
+      <MapDataLoader dataType={dataType} />
 
       <TopCommandBar
         selectedDate={selectedDate}

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -102,12 +102,8 @@ const MapPage: FC = () => {
     setSearchParams({ date: selectedDate }, { replace: true });
   }, [selectedDate, setSearchParams]);
 
-  // update store when data changes based on selected data type. Loading
-  // flags pass through unconditionally so tier detection stays accurate;
-  // the displayed-data writes are deferred while a pan/zoom gesture is
-  // active so the layer rebuild + transition can't stall the next frame.
-  // When isGesturing flips back to false this effect re-runs and the
-  // pending data flushes in a single shot.
+  // Defer displayed-data writes while gesturing so the layer rebuild can't
+  // stall the pan; loading flags pass through for accurate tier detection.
   useEffect(() => {
     if (isSunshineSelected) {
       setIsLoadingSunshine(isSunshineLoading);

--- a/client/src/stores/useAppStore.ts
+++ b/client/src/stores/useAppStore.ts
@@ -19,8 +19,7 @@ interface AppState {
   setTemperatureUnit: (unit: TemperatureUnit) => void;
   mapViewport: MapViewport | null;
   setMapViewport: (viewport: MapViewport) => void;
-  // True while the user is actively panning/zooming the map. Map data
-  // updates skip the displayed-data Zustand stores while this is true so
+  // True while panning/zooming. Displayed-data writes skip while true so
   // the gesture isn't blocked by a layer rebuild + transition.
   isGesturing: boolean;
   setIsGesturing: (gesturing: boolean) => void;

--- a/client/src/stores/useAppStore.ts
+++ b/client/src/stores/useAppStore.ts
@@ -19,6 +19,11 @@ interface AppState {
   setTemperatureUnit: (unit: TemperatureUnit) => void;
   mapViewport: MapViewport | null;
   setMapViewport: (viewport: MapViewport) => void;
+  // True while the user is actively panning/zooming the map. Map data
+  // updates skip the displayed-data Zustand stores while this is true so
+  // the gesture isn't blocked by a layer rebuild + transition.
+  isGesturing: boolean;
+  setIsGesturing: (gesturing: boolean) => void;
   resetHomeLocation: () => void;
 }
 
@@ -40,6 +45,8 @@ export const useAppStore = create<AppState>()(
       setTemperatureUnit: (temperatureUnit) => set({ temperatureUnit }),
       mapViewport: null,
       setMapViewport: (mapViewport) => set({ mapViewport }),
+      isGesturing: false,
+      setIsGesturing: (isGesturing) => set({ isGesturing }),
       resetHomeLocation: () =>
         set({
           homeLocation: null,

--- a/client/src/stores/usePerformanceStore.ts
+++ b/client/src/stores/usePerformanceStore.ts
@@ -1,60 +1,37 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import type { PerformanceMetric } from '@/utils/performance/performanceMonitor';
 
+// In-memory only. Was previously wrapped in zustand/persist + localStorage,
+// but every perfMonitor.end() during a layer rebuild fired a JSON.stringify +
+// localStorage.setItem on the (growing) metrics array, which on long dev
+// sessions stalled gestures by 5-50 ms per write. The dashboard still works
+// from the in-memory copy; metrics just don't survive a reload.
+
 interface PerformanceState {
-  // Dashboard visibility
   isVisible: boolean;
   setIsVisible: (visible: boolean) => void;
 
-  // Persisted metrics (with limit to prevent quota issues)
   metrics: PerformanceMetric[];
   setMetrics: (metrics: PerformanceMetric[]) => void;
   addMetric: (metric: PerformanceMetric) => void;
   clearMetrics: () => void;
 }
 
-// Maximum number of metrics to keep in storage (prevent quota exceeded)
 const MAX_STORED_METRICS = 100;
 
-export const usePerformanceStore = create<PerformanceState>()(
-  persist(
-    (set) => ({
-      isVisible: false,
-      setIsVisible: (isVisible) => set({ isVisible }),
+export const usePerformanceStore = create<PerformanceState>()((set) => ({
+  isVisible: false,
+  setIsVisible: (isVisible) => set({ isVisible }),
 
-      metrics: [],
-      setMetrics: (metrics) => set({ metrics }),
-      addMetric: (metric) =>
-        set((state) => {
-          // Keep only the most recent metrics to prevent localStorage quota issues
-          const newMetrics = [...state.metrics, metric];
-          if (newMetrics.length > MAX_STORED_METRICS) {
-            // Remove oldest metrics, keep most recent
-            return { metrics: newMetrics.slice(-MAX_STORED_METRICS) };
-          }
-          return { metrics: newMetrics };
-        }),
-      clearMetrics: () => set({ metrics: [] }),
+  metrics: [],
+  setMetrics: (metrics) => set({ metrics }),
+  addMetric: (metric) =>
+    set((state) => {
+      const newMetrics = [...state.metrics, metric];
+      if (newMetrics.length > MAX_STORED_METRICS) {
+        return { metrics: newMetrics.slice(-MAX_STORED_METRICS) };
+      }
+      return { metrics: newMetrics };
     }),
-    {
-      name: 'performance-dashboard-storage',
-      // Persist everything
-      partialize: (state) => ({
-        isVisible: state.isVisible,
-        // Only persist a limited number of metrics
-        metrics: state.metrics.slice(-MAX_STORED_METRICS),
-      }),
-      // Handle storage errors gracefully
-      onRehydrateStorage: () => (state, error) => {
-        if (error) {
-          console.warn('Failed to rehydrate performance store:', error);
-          // Clear metrics on error to recover
-          if (state) {
-            state.metrics = [];
-          }
-        }
-      },
-    }
-  )
-);
+  clearMetrics: () => set({ metrics: [] }),
+}));

--- a/client/src/tests/components/CityPopup/Ribbon/IconTabs.test.tsx
+++ b/client/src/tests/components/CityPopup/Ribbon/IconTabs.test.tsx
@@ -44,4 +44,18 @@ describe('IconTabs', () => {
     fireEvent.click(screen.getByRole('button', { name: /temp/i }));
     expect(onTab).toHaveBeenCalledWith(DataType.Temperature);
   });
+
+  it('hides tabs not present in availableTabs', () => {
+    render(
+      <IconTabs
+        tab={DataType.Temperature}
+        onTab={vi.fn()}
+        availableTabs={[DataType.Temperature, DataType.Precip]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /temp/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /precip/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /sun/i })).toBeNull();
+  });
 });

--- a/client/src/tests/components/CityPopup/Ribbon/RibbonShell.test.tsx
+++ b/client/src/tests/components/CityPopup/Ribbon/RibbonShell.test.tsx
@@ -108,6 +108,60 @@ describe('RibbonShell', () => {
     expect(firstHoverFn).toBe(lastHoverFn);
   });
 
+  it('hides tabs not in availableTabs and falls back to the first available tab', () => {
+    const renderChart = vi.fn(
+      (
+        _tab: DataType,
+        _onHover: (
+          payload: {
+            label: string;
+            v1: string | null;
+            v2: string | null;
+          } | null
+        ) => void
+      ) => <div data-testid="chart-slot">chart</div>
+    );
+    render(
+      <RibbonShell
+        {...baseProps}
+        initialTab={DataType.Sunshine}
+        availableTabs={[DataType.Temperature, DataType.Precip]}
+        renderChart={renderChart}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /sun/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /temp/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(renderChart.mock.calls[0][0]).toBe(DataType.Temperature);
+  });
+
+  it('renders the active tab note from notesByTab next to the tabs', () => {
+    render(
+      <RibbonShell
+        {...baseProps}
+        initialTab={DataType.Sunshine}
+        availableTabs={[
+          DataType.Temperature,
+          DataType.Sunshine,
+          DataType.Precip,
+        ]}
+        notesByTab={{
+          [DataType.Sunshine]: (
+            <span data-testid="sun-note">No sunshine data for Berlin</span>
+          ),
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('sun-note')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /temp/i }));
+    expect(screen.queryByTestId('sun-note')).toBeNull();
+  });
+
   it('shows comparison row only when comparisonCity is provided', () => {
     const comparisonCity: SearchCitiesResult = {
       id: 2,

--- a/client/src/tests/components/Map/MapDataLoader.test.tsx
+++ b/client/src/tests/components/Map/MapDataLoader.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@/test-utils';
+import MapDataLoader from '@/components/Map/MapDataLoader';
+import { useAppStore } from '@/stores/useAppStore';
+import { useWeatherStore } from '@/stores/useWeatherStore';
+import { useSunshineStore } from '@/stores/useSunshineStore';
+import { DataType } from '@/types/mapTypes';
+
+describe('MapDataLoader', () => {
+  beforeEach(() => {
+    useAppStore.setState({ isGesturing: false });
+    useWeatherStore.setState({ isLoadingWeather: false });
+    useSunshineStore.setState({ isLoadingSunshine: false });
+  });
+
+  it('renders the spinner when the user is gesturing', () => {
+    useAppStore.setState({ isGesturing: true });
+    render(<MapDataLoader dataType={DataType.Temperature} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders the spinner when weather is loading and dataType is Temperature', () => {
+    useWeatherStore.setState({ isLoadingWeather: true });
+    render(<MapDataLoader dataType={DataType.Temperature} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders the spinner when sunshine is loading and dataType is Sunshine', () => {
+    useSunshineStore.setState({ isLoadingSunshine: true });
+    render(<MapDataLoader dataType={DataType.Sunshine} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('ignores the off-tab loading flag — sunshine loading is invisible on the Temperature tab', () => {
+    useSunshineStore.setState({ isLoadingSunshine: true });
+    render(<MapDataLoader dataType={DataType.Temperature} />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('ignores the off-tab loading flag — weather loading is invisible on the Sunshine tab', () => {
+    useWeatherStore.setState({ isLoadingWeather: true });
+    render(<MapDataLoader dataType={DataType.Sunshine} />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('does not render the spinner when neither gesturing nor loading', () => {
+    render(<MapDataLoader dataType={DataType.Temperature} />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('exposes an aria-label so screen readers announce the loading state', () => {
+    useAppStore.setState({ isGesturing: true });
+    render(<MapDataLoader dataType={DataType.Temperature} />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Loading map data'
+    );
+  });
+});

--- a/client/src/tests/utils/dataFormatting/hasSunshineData.test.ts
+++ b/client/src/tests/utils/dataFormatting/hasSunshineData.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import type { SunshineData } from '@/types/sunshineDataType';
+import { hasSunshineData } from '@/utils/dataFormatting/hasSunshineData';
+
+const allNullMonths: SunshineData = {
+  cityId: 1,
+  city: 'Empty',
+  country: 'US',
+  lat: 40.7,
+  long: -74,
+  population: null,
+  jan: null,
+  feb: null,
+  mar: null,
+  apr: null,
+  may: null,
+  jun: null,
+  jul: null,
+  aug: null,
+  sep: null,
+  oct: null,
+  nov: null,
+  dec: null,
+};
+
+describe('hasSunshineData', () => {
+  it('returns false when data is null or undefined', () => {
+    expect(hasSunshineData(null)).toBe(false);
+    expect(hasSunshineData(undefined)).toBe(false);
+  });
+
+  it('returns false when every month is null', () => {
+    expect(hasSunshineData(allNullMonths)).toBe(false);
+  });
+
+  it('returns true when any month has a numeric value', () => {
+    expect(hasSunshineData({ ...allNullMonths, jul: 250 })).toBe(true);
+    expect(hasSunshineData({ ...allNullMonths, jan: 0 })).toBe(true);
+  });
+});

--- a/client/src/utils/dataFormatting/hasSunshineData.ts
+++ b/client/src/utils/dataFormatting/hasSunshineData.ts
@@ -1,0 +1,15 @@
+import type { SunshineData } from '@/types/sunshineDataType';
+import { getMonthlySunshineHours } from './getMonthlySunshineHours';
+
+// True when SunshineData contains at least one numeric monthly value. A row
+// can come back populated with all-null months for stations with no readings —
+// that should count as "no data" for tab visibility.
+export function hasSunshineData(
+  data: SunshineData | null | undefined
+): boolean {
+  if (!data) return false;
+  for (let month = 1; month <= 12; month++) {
+    if (getMonthlySunshineHours(data, month) !== null) return true;
+  }
+  return false;
+}

--- a/client/src/utils/performance/performanceMonitor.ts
+++ b/client/src/utils/performance/performanceMonitor.ts
@@ -11,45 +11,17 @@ class PerformanceMonitor {
   private metrics: PerformanceMetric[] = [];
   private marks: Map<string, number> = new Map();
 
+  // One-time cleanup of any leftover persisted metrics from a previous build
+  // that wrote to localStorage. After this runs once, the key never reappears
+  // because the store no longer uses zustand/persist.
   constructor() {
-    // Load persisted metrics on startup (non-blocking)
     if (typeof globalThis.window !== 'undefined' && import.meta.env.DEV) {
-      this.clearCorruptedStorage();
-      this.loadPersistedMetrics();
-    }
-  }
-
-  private clearCorruptedStorage(): void {
-    // Clear corrupted storage if it exists and is causing issues
-    try {
-      const stored = localStorage.getItem('performance-dashboard-storage');
-      if (stored && stored.length > 500000) {
-        // > 500KB is suspicious
-        console.warn('Detected large performance storage, clearing...');
-        localStorage.removeItem('performance-dashboard-storage');
-      }
-    } catch (err) {
-      // If we can't even check, just clear it
       try {
         localStorage.removeItem('performance-dashboard-storage');
       } catch {
-        // Give up silently
+        // Ignore — storage may be disabled or unavailable.
       }
     }
-  }
-
-  private loadPersistedMetrics(): void {
-    // Async load without blocking constructor
-    import('@/stores/usePerformanceStore')
-      .then(({ usePerformanceStore }) => {
-        const persistedMetrics = usePerformanceStore.getState().metrics;
-        if (persistedMetrics.length > 0) {
-          this.metrics = [...persistedMetrics];
-        }
-      })
-      .catch((err) => {
-        console.warn('Failed to load persisted metrics:', err);
-      });
   }
 
   start(name: string): void {
@@ -99,41 +71,16 @@ class PerformanceMonitor {
   }
 
   private syncToStore(metric: PerformanceMetric): void {
-    if (typeof globalThis.window !== 'undefined') {
-      // Use try-catch to prevent infinite loops on quota errors
-      try {
-        import('@/stores/usePerformanceStore')
-          .then(({ usePerformanceStore }) => {
-            try {
-              usePerformanceStore.getState().addMetric(metric);
-            } catch (storageError) {
-              // If we hit quota, clear old metrics and try once more
-              if (
-                storageError instanceof Error &&
-                storageError.name === 'QuotaExceededError'
-              ) {
-                console.warn(
-                  'localStorage quota exceeded, clearing old metrics'
-                );
-                usePerformanceStore.getState().clearMetrics();
-              } else {
-                throw storageError;
-              }
-            }
-          })
-          .catch((err) => {
-            // Silent fail - don't let monitoring break the app
-            if (import.meta.env.DEV) {
-              console.warn('Failed to sync metric to store:', err);
-            }
-          });
-      } catch (err) {
-        // Catch any synchronous errors
+    if (typeof globalThis.window === 'undefined') return;
+    import('@/stores/usePerformanceStore')
+      .then(({ usePerformanceStore }) => {
+        usePerformanceStore.getState().addMetric(metric);
+      })
+      .catch((err) => {
         if (import.meta.env.DEV) {
-          console.warn('Error in syncToStore:', err);
+          console.warn('Failed to sync metric to store:', err);
         }
-      }
-    }
+      });
   }
 
   private getThreshold(name: string): number {

--- a/client/src/utils/performance/performanceMonitor.ts
+++ b/client/src/utils/performance/performanceMonitor.ts
@@ -11,15 +11,14 @@ class PerformanceMonitor {
   private metrics: PerformanceMetric[] = [];
   private marks: Map<string, number> = new Map();
 
-  // One-time cleanup of any leftover persisted metrics from a previous build
-  // that wrote to localStorage. After this runs once, the key never reappears
-  // because the store no longer uses zustand/persist.
+  // One-time cleanup of leftover persisted metrics from the previous build.
+  // The key won't reappear since the store no longer uses zustand/persist.
   constructor() {
     if (typeof globalThis.window !== 'undefined' && import.meta.env.DEV) {
       try {
         localStorage.removeItem('performance-dashboard-storage');
-      } catch {
-        // Ignore — storage may be disabled or unavailable.
+      } catch (err) {
+        console.warn('perf storage cleanup skipped:', err);
       }
     }
   }


### PR DESCRIPTION
## Summary

Phase 1 of the map-pan perf work: eliminates the frame stalls users hit when panning/zooming a populated viewport. Root cause was multiple concurrent stalls firing during a gesture — full-resolution rasterisation on HiDPI, 400-600 ms marker transitions on every layer rebuild, ghost-dot grids + breathe pulses overlapping real markers, a `zustand/persist` write on every `perfMonitor.end()`, and a Zustand subscription in `useMapBounds` re-rendering `WorldMap` on every viewport tick.

The biggest single fix is a new `isGesturing` flag with an 800 ms grace window: while it's true, bounds-query results don't flush into the displayed-data stores and decorative layers (breathe pulse, ghost dots) are suppressed. A small spinner (`MapDataLoader`) is the single source of "loading is happening" feedback during the pan→flush window.

Also includes a small drive-by: gating the CityPopup Sunshine tab behind a new `hasSunshineData` util so cities with no sunshine data don't render an empty tab.

## Key changes

**Gesture-aware data flush**
- New `isGesturing` flag in `useAppStore` driven by `useMapBounds` (split into separate 300 ms bounds-query + 800 ms gesture-grace timers).
- `map.tsx` defers `setDisplayedWeatherData` / `setDisplayedSunshineData` writes while gesturing; loading flags still pass through for accurate tier detection.
- `useMapBounds` reads `mapViewport` once at mount via `getState()` instead of subscribing — kills 60 Hz re-renders of `WorldMap`.

**Loading UI**
- New `MapDataLoader` spinner (top-right, `role="status"`, `aria-live="polite"`).
- Breathe pulse + ghost-dot grid gated on `tier === 'tier2' && !isGesturing`.
- Tier-1 full-screen overlay is now `pointer-events-none` so it can't eat clicks.

**Marker / map rendering**
- Marker `getFillColor` / `opacity` / `getRadius` transitions: 400-600 ms → 80 ms.
- `useDevicePixels` capped at 1.5× — 2×/3× displays were rasterising 4×/9× more fragments per frame for an imperceptible visual gain.
- `scrollZoom.speed` reduced from 15× default to 3× (named `MAP_SCROLL_ZOOM_SPEED`); dropped `smooth: true` (bad fit for trackpad pinch).

**Performance store**
- Dropped `zustand/persist` from `usePerformanceStore`. Each `addMetric` was firing `JSON.stringify` + `localStorage.setItem` on a growing array — 5-50 ms stalls per write on long dev sessions. Dashboard still works in-memory; metrics no longer survive reload.
- `performanceMonitor` constructor does a one-time `localStorage.removeItem` for the legacy persisted key.

**CityPopup (drive-by)**
- New `hasSunshineData` util; ribbon hides the Sunshine icon-tab when a city has no sunshine values.

## Test plan

- [ ] Pan + zoom around the map at zoom ≥ 2 (`ZOOM_THRESHOLD`) — no visible frame drops, no marker pop/flash mid-gesture.
- [ ] Quick pan → pause → pan: breathe pulse + ghost dots stay hidden through the whole sequence; spinner stays visible until ~800 ms after the last move.
- [ ] Spinner shows while loading on initial map mount and hides once data lands.
- [ ] Switch between Temperature and Sunshine tabs while panning — spinner tracks the correct loading flag per tab.
- [ ] Open CityPopup on a city with sunshine data → Sunshine tab present. Open one without → Sunshine tab hidden.
- [ ] Tier-1 full-screen loading overlay no longer blocks clicks on the command bar / legend.
- [ ] Dev perf dashboard (`window.perfMonitor`) still records and displays metrics; reload clears them (expected).
- [ ] No new TS / ESLint errors; all existing + new tests pass (`npm test`).
