### PR TITLE
feat(mobile): MobileDateScrubber persistent bottom bar

### DIFF
--- a/.claude/commands/pr-review-vaycay.md
+++ b/.claude/commands/pr-review-vaycay.md
@@ -19,11 +19,13 @@ Fire all of these in parallel before reading any source files:
 - `git diff --stat origin/master...HEAD` — scope (files + line counts)
 - `git diff --name-only origin/master...HEAD` — file list
 - `git diff origin/master...HEAD` — the actual diff
-- `cd client && npm run lint -- --quiet 2>&1 | tail -50` (only if `client/` files changed)
-- `cd client && npm run type-check 2>&1 | tail -50` (only if `client/` files changed)
-- `cd server && npm run lint -- --quiet 2>&1 | tail -50` (only if `server/` files changed)
-- `cd server && npm run type-check 2>&1 | tail -50` (only if `server/` files changed)
-- `npm run knip 2>&1 | tail -50` (root — unused exports, dead code)
+- `cd "$(git rev-parse --show-toplevel)/client" && npm run lint -- --quiet 2>&1 | tail -50` (only if `client/` files changed)
+- `cd "$(git rev-parse --show-toplevel)/client" && npm run type-check 2>&1 | tail -50` (only if `client/` files changed)
+- `cd "$(git rev-parse --show-toplevel)/server" && npm run lint -- --quiet 2>&1 | tail -50` (only if `server/` files changed)
+- `cd "$(git rev-parse --show-toplevel)/server" && npm run type-check 2>&1 | tail -50` (only if `server/` files changed)
+- `cd "$(git rev-parse --show-toplevel)" && npm run knip 2>&1 | tail -50` (root — unused exports, dead code; knip script lives at repo root, NOT in client/ or server/)
+
+Note: Bash tool CWD persists across parallel tool calls. Always use absolute paths via `$(git rev-parse --show-toplevel)` so a concurrent `cd client` in one call doesn't leave the CWD wrong for another.
 
 Use lint + tsc + knip findings as a free first pass. Don't re-flag what they already caught — surface them in a "Static analysis" section of your report and move on.
 

--- a/.claude/commands/pr-review-vaycay.md
+++ b/.claude/commands/pr-review-vaycay.md
@@ -81,6 +81,7 @@ Apply CLAUDE.md to each changed file. One-liners below are reminders, not the fu
 
 1. **File structure** — one function/component per file (HARD), filename matches, default export for components, constants in `constants.ts`/`const.ts`, types in `types/` (except component props).
    *Serena:* `get_symbols_overview` on each changed file — if it returns more than one top-level function/class/component export, flag it.
+   *ripgrep:* For any changed `.tsx` file, also run `rg -n 'const \w+ = \($' <file>` — a `const X = (` at end of line is the signature of an inline JSX sub-render that should be its own component file. Flag every hit.
 2. **Code duplication** — type guards consolidated in `utils/typeGuards.ts`; repeated logic extracted; near-duplicate components/hooks unified.
    *Serena:* before flagging "this looks duplicate", run `find_symbol` on the candidate name. Before flagging "extract this", run `find_referencing_symbols` to size blast radius.
 3. **State management** — no `useState`+`useEffect` for derived data; no `useMemo` around already-memoized fns; Zustand individual selectors only.

--- a/client/src/components/Map/LegendSwatches.tsx
+++ b/client/src/components/Map/LegendSwatches.tsx
@@ -1,0 +1,48 @@
+import type { FC } from 'react';
+import { ColorSwatch, Text } from '@mantine/core';
+import { TEMP_THRESHOLDS, SUNSHINE_THRESHOLDS } from '@/const';
+import { DataType } from '@/types/mapTypes';
+import { useAppStore } from '@/stores/useAppStore';
+import rgbToString from '@/components/Map/utils/rgbToString';
+import formatLegendLabel from '@/components/Map/utils/formatLegendLabel';
+
+interface LegendSwatchesProps {
+  dataType: DataType;
+}
+
+const LegendSwatches: FC<LegendSwatchesProps> = ({ dataType }) => {
+  const temperatureUnit = useAppStore((s) => s.temperatureUnit);
+  const isSunshine = dataType === DataType.Sunshine;
+  const thresholds = isSunshine ? SUNSHINE_THRESHOLDS : TEMP_THRESHOLDS;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {thresholds.map((threshold, index) => {
+        const keyValue =
+          'temp' in threshold ? threshold.temp : threshold.percent;
+
+        return (
+          <div key={keyValue} className="flex items-center gap-2 flex-nowrap">
+            <ColorSwatch
+              color={rgbToString(threshold.color)}
+              size={16}
+              style={{ minWidth: 16 }}
+            />
+            <Text
+              size="xs"
+              style={{
+                color: 'currentColor',
+                opacity: 0.6,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {formatLegendLabel(index, isSunshine, temperatureUnit)}
+            </Text>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default LegendSwatches;

--- a/client/src/components/Map/MapColorLegend.tsx
+++ b/client/src/components/Map/MapColorLegend.tsx
@@ -1,16 +1,11 @@
 import { useState } from 'react';
 import type { FC } from 'react';
-import { Collapse, ColorSwatch, Text, UnstyledButton } from '@mantine/core';
+import { Collapse, UnstyledButton, Text } from '@mantine/core';
 import { IconChevronDown } from '@tabler/icons-react';
-import { TEMP_THRESHOLDS, SUNSHINE_THRESHOLDS } from '@/const';
 import { DataType } from '@/types/mapTypes';
-import { useAppStore } from '@/stores/useAppStore';
 import useGlassTokens from '@/hooks/useGlassTokens';
 import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
-import {
-  convertTemperature,
-  getTemperatureUnitSymbol,
-} from '@/utils/tempFormatting/convertTemperature';
+import LegendSwatches from '@/components/Map/LegendSwatches';
 
 interface MapColorLegendProps {
   dataType: DataType;
@@ -18,78 +13,8 @@ interface MapColorLegendProps {
 
 const MapColorLegend: FC<MapColorLegendProps> = ({ dataType }) => {
   const [opened, setOpened] = useState(false);
-  const isSunshine = dataType === DataType.Sunshine;
-  const temperatureUnit = useAppStore((state) => state.temperatureUnit);
-  const unitSymbol = getTemperatureUnitSymbol(temperatureUnit);
   const glass = useGlassTokens();
   const isMobileOrSmall = useIsMobileOrSmall();
-
-  // Convert RGB array to CSS rgb() string
-  const rgbToString = (
-    rgb: readonly [number, number, number] | [number, number, number]
-  ) => {
-    return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
-  };
-
-  // Format label text based on data type with proper typing
-  const formatLabel = (index: number) => {
-    if (isSunshine) {
-      const threshold = SUNSHINE_THRESHOLDS[index];
-      const nextThreshold = SUNSHINE_THRESHOLDS[index + 1];
-      if (nextThreshold) {
-        return `${threshold.percent} → ${nextThreshold.percent}%`;
-      }
-      return `${threshold.percent}%+`;
-    } else {
-      const threshold = TEMP_THRESHOLDS[index];
-      const nextThreshold = TEMP_THRESHOLDS[index + 1];
-
-      const convertedTemp = Math.round(
-        convertTemperature(threshold.temp, temperatureUnit)
-      );
-
-      if (nextThreshold) {
-        const convertedNextTemp = Math.round(
-          convertTemperature(nextThreshold.temp, temperatureUnit)
-        );
-        return `${convertedTemp} → ${convertedNextTemp}${unitSymbol}`;
-      }
-      return `${convertedTemp}${unitSymbol}+`;
-    }
-  };
-
-  const thresholds = isSunshine ? SUNSHINE_THRESHOLDS : TEMP_THRESHOLDS;
-  const displayedIndices = thresholds.map((_, index) => index);
-
-  const swatches = (
-    <div className="flex flex-col gap-2">
-      {displayedIndices.map((index) => {
-        const threshold = thresholds[index];
-        const keyValue =
-          'temp' in threshold ? threshold.temp : threshold.percent;
-
-        return (
-          <div key={keyValue} className="flex items-center gap-2 flex-nowrap">
-            <ColorSwatch
-              color={rgbToString(threshold.color)}
-              size={16}
-              style={{ minWidth: 16 }}
-            />
-            <Text
-              size="xs"
-              style={{
-                color: 'currentColor',
-                opacity: 0.6,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {formatLabel(index)}
-            </Text>
-          </div>
-        );
-      })}
-    </div>
-  );
 
   return (
     <div
@@ -104,7 +29,7 @@ const MapColorLegend: FC<MapColorLegendProps> = ({ dataType }) => {
       }}
     >
       {isMobileOrSmall ? (
-        swatches
+        <LegendSwatches dataType={dataType} />
       ) : (
         <>
           <UnstyledButton
@@ -136,7 +61,9 @@ const MapColorLegend: FC<MapColorLegendProps> = ({ dataType }) => {
             </div>
           </UnstyledButton>
           <Collapse in={opened}>
-            <div className="pt-2">{swatches}</div>
+            <div className="pt-2">
+              <LegendSwatches dataType={dataType} />
+            </div>
           </Collapse>
         </>
       )}

--- a/client/src/components/Map/MapColorLegend.tsx
+++ b/client/src/components/Map/MapColorLegend.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import type { FC } from 'react';
 import { Collapse, UnstyledButton, Text } from '@mantine/core';
 import { IconChevronDown } from '@tabler/icons-react';
-import { DataType } from '@/types/mapTypes';
+import type { DataType } from '@/types/mapTypes';
 import useGlassTokens from '@/hooks/useGlassTokens';
 import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
 import LegendSwatches from '@/components/Map/LegendSwatches';

--- a/client/src/components/Map/utils/formatLegendLabel.ts
+++ b/client/src/components/Map/utils/formatLegendLabel.ts
@@ -1,5 +1,5 @@
 import { TEMP_THRESHOLDS, SUNSHINE_THRESHOLDS } from '@/const';
-import { TemperatureUnit } from '@/types/mapTypes';
+import type { TemperatureUnit } from '@/types/mapTypes';
 import {
   convertTemperature,
   getTemperatureUnitSymbol,

--- a/client/src/components/Map/utils/formatLegendLabel.ts
+++ b/client/src/components/Map/utils/formatLegendLabel.ts
@@ -1,0 +1,38 @@
+import { TEMP_THRESHOLDS, SUNSHINE_THRESHOLDS } from '@/const';
+import { TemperatureUnit } from '@/types/mapTypes';
+import {
+  convertTemperature,
+  getTemperatureUnitSymbol,
+} from '@/utils/tempFormatting/convertTemperature';
+
+const formatLegendLabel = (
+  index: number,
+  isSunshine: boolean,
+  temperatureUnit: TemperatureUnit
+): string => {
+  if (isSunshine) {
+    const threshold = SUNSHINE_THRESHOLDS[index];
+    const nextThreshold = SUNSHINE_THRESHOLDS[index + 1];
+    if (nextThreshold) {
+      return `${threshold.percent} → ${nextThreshold.percent}%`;
+    }
+    return `${threshold.percent}%+`;
+  }
+
+  const threshold = TEMP_THRESHOLDS[index];
+  const nextThreshold = TEMP_THRESHOLDS[index + 1];
+  const unitSymbol = getTemperatureUnitSymbol(temperatureUnit);
+  const convertedTemp = Math.round(
+    convertTemperature(threshold.temp, temperatureUnit)
+  );
+
+  if (nextThreshold) {
+    const convertedNextTemp = Math.round(
+      convertTemperature(nextThreshold.temp, temperatureUnit)
+    );
+    return `${convertedTemp} → ${convertedNextTemp}${unitSymbol}`;
+  }
+  return `${convertedTemp}${unitSymbol}+`;
+};
+
+export default formatLegendLabel;

--- a/client/src/components/Map/utils/rgbToString.ts
+++ b/client/src/components/Map/utils/rgbToString.ts
@@ -1,0 +1,5 @@
+const rgbToString = (
+  rgb: readonly [number, number, number] | [number, number, number]
+) => `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+
+export default rgbToString;

--- a/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
+++ b/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
@@ -21,9 +21,21 @@ const SliderMarks: FC<SliderMarksProps> = ({ marks, min, max }) => {
             className="absolute -translate-x-1/2"
             style={{ left: `${markPosition}%` }}
           >
-            <Text size="xs" style={{ color: glass.text, opacity: 0.7 }}>
-              {mark.label}
-            </Text>
+            {mark.label ? (
+              <Text size="xs" style={{ color: glass.text, opacity: 0.7 }}>
+                {mark.label}
+              </Text>
+            ) : (
+              <div
+                aria-hidden="true"
+                style={{
+                  width: 1,
+                  height: 6,
+                  background: glass.text,
+                  opacity: 0.35,
+                }}
+              />
+            )}
           </div>
         );
       })}

--- a/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
+++ b/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { Text } from '@mantine/core';
 import useGlassTokens from '@/hooks/useGlassTokens';
+import { SLIDER_MARK_TICK_WIDTH_PX, SLIDER_MARK_TICK_HEIGHT_PX } from '@/const';
 
 interface SliderMarksProps {
   marks: Array<{ value: number; label: string }>;
@@ -24,8 +25,8 @@ const SliderMarks: FC<SliderMarksProps> = ({ marks, min, max }) => {
             <div
               aria-hidden="true"
               style={{
-                width: 1,
-                height: 6,
+                width: SLIDER_MARK_TICK_WIDTH_PX,
+                height: SLIDER_MARK_TICK_HEIGHT_PX,
                 background: glass.text,
                 opacity: 0.35,
               }}

--- a/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
+++ b/client/src/components/Navigation/DateSliderParts/SliderMarks.tsx
@@ -18,23 +18,22 @@ const SliderMarks: FC<SliderMarksProps> = ({ marks, min, max }) => {
         return (
           <div
             key={mark.value}
-            className="absolute -translate-x-1/2"
+            className="absolute -translate-x-1/2 flex flex-col items-center"
             style={{ left: `${markPosition}%` }}
           >
-            {mark.label ? (
+            <div
+              aria-hidden="true"
+              style={{
+                width: 1,
+                height: 6,
+                background: glass.text,
+                opacity: 0.35,
+              }}
+            />
+            {mark.label && (
               <Text size="xs" style={{ color: glass.text, opacity: 0.7 }}>
                 {mark.label}
               </Text>
-            ) : (
-              <div
-                aria-hidden="true"
-                style={{
-                  width: 1,
-                  height: 6,
-                  background: glass.text,
-                  opacity: 0.35,
-                }}
-              />
             )}
           </div>
         );

--- a/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
+++ b/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
@@ -1,27 +1,101 @@
-import { MOBILE_BAR_INSET_PX } from '@/const';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
+import { Text } from '@mantine/core';
+import { dateToDayOfYear } from '@/utils/dateFormatting/dateToDayOfYear';
+import { dayOfYearToDate } from '@/utils/dateFormatting/dayOfYearToDate';
+import formatSliderValueForLabel from '@/utils/dateFormatting/formatSliderValueForLabel';
+import CustomDateSlider from '@/components/Navigation/CustomDateSlider';
+import useGlassTokens from '@/hooks/useGlassTokens';
+import {
+  monthMarks,
+  monthlyMarks,
+  MOBILE_BAR_INSET_PX,
+  MOBILE_BAR_RADIUS_PX,
+  MOBILE_SCRUBBER_BOTTOM_PX,
+} from '@/const';
 
 interface MobileDateScrubberProps {
   selectedDate: string;
+  onDateChange: (date: string) => void;
+  isMonthly?: boolean;
   hidden?: boolean;
 }
 
-// Stub — full date scrubber not yet implemented.
-const MobileDateScrubber = ({
+const MobileDateScrubber: FC<MobileDateScrubberProps> = ({
   selectedDate,
+  onDateChange,
+  isMonthly = false,
   hidden = false,
-}: MobileDateScrubberProps) => {
+}) => {
+  const glass = useGlassTokens();
+
+  const sliderValue = isMonthly
+    ? Number.parseInt(selectedDate.substring(0, 2), 10)
+    : dateToDayOfYear(selectedDate);
+
+  // Tracks the value while the user is dragging so the trailing label updates
+  // live, before onDateChange commits on pointer-release.
+  const [previewValue, setPreviewValue] = useState<number | null>(null);
+
+  // Drop the preview once a new value arrives via prop (commit landed,
+  // or external date change e.g. URL).
+  useEffect(() => {
+    setPreviewValue(null);
+  }, [sliderValue]);
+
+  const handleSliderChange = (value: number) => {
+    const newDate = isMonthly
+      ? `${value.toString().padStart(2, '0')}-15`
+      : dayOfYearToDate(value);
+    onDateChange(newDate);
+  };
+
+  const marks = isMonthly ? [...monthlyMarks] : [...monthMarks];
+  const maxValue = isMonthly ? 12 : 365;
+
+  const labelValue = previewValue ?? sliderValue;
+  const currentLabel = formatSliderValueForLabel(labelValue, isMonthly);
+
   return (
     <div
-      className="absolute z-20 flex items-center justify-center"
+      data-testid="mobile-date-scrubber"
+      className="z-20 flex items-center gap-4 px-4 py-3"
       style={{
-        bottom: MOBILE_BAR_INSET_PX,
+        position: 'fixed',
+        bottom: MOBILE_SCRUBBER_BOTTOM_PX,
         left: MOBILE_BAR_INSET_PX,
         right: MOBILE_BAR_INSET_PX,
+        borderRadius: MOBILE_BAR_RADIUS_PX,
+        background: glass.bgStrong,
+        backdropFilter: glass.blurStrong,
+        WebkitBackdropFilter: glass.blurStrong,
+        border: `1px solid ${glass.borderLight}`,
+        boxShadow: glass.shadow,
         transform: hidden ? 'translateY(120%)' : 'translateY(0)',
         transition: 'transform 250ms ease',
       }}
     >
-      <span>DATE: {selectedDate}</span>
+      <div className="flex-1">
+        <CustomDateSlider
+          value={sliderValue}
+          onChange={handleSliderChange}
+          onValuePreview={setPreviewValue}
+          min={1}
+          max={maxValue}
+          marks={marks}
+          isMonthly={isMonthly}
+        />
+      </div>
+
+      <Text
+        size="xs"
+        c="dimmed"
+        fw={500}
+        ff="monospace"
+        className="shrink-0 min-w-16 text-right"
+      >
+        {currentLabel}
+      </Text>
     </div>
   );
 };

--- a/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
+++ b/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
@@ -50,7 +50,7 @@ const MobileDateScrubber: FC<MobileDateScrubberProps> = ({
     onDateChange(newDate);
   };
 
-  const marks = isMonthly ? [...monthlyMarksMobile] : [...monthMarksMobile];
+  const marks = isMonthly ? monthlyMarksMobile : monthMarksMobile;
   const maxValue = isMonthly ? 12 : 365;
 
   const labelValue = previewValue ?? sliderValue;

--- a/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
+++ b/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
@@ -7,8 +7,8 @@ import formatSliderValueForLabel from '@/utils/dateFormatting/formatSliderValueF
 import CustomDateSlider from '@/components/Navigation/CustomDateSlider';
 import useGlassTokens from '@/hooks/useGlassTokens';
 import {
-  monthMarksShort,
-  monthlyMarksShort,
+  monthMarksMobile,
+  monthlyMarksMobile,
   MOBILE_BAR_INSET_PX,
   MOBILE_BAR_RADIUS_PX,
   MOBILE_SCRUBBER_BOTTOM_PX,
@@ -50,7 +50,7 @@ const MobileDateScrubber: FC<MobileDateScrubberProps> = ({
     onDateChange(newDate);
   };
 
-  const marks = isMonthly ? [...monthlyMarksShort] : [...monthMarksShort];
+  const marks = isMonthly ? [...monthlyMarksMobile] : [...monthMarksMobile];
   const maxValue = isMonthly ? 12 : 365;
 
   const labelValue = previewValue ?? sliderValue;

--- a/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
+++ b/client/src/components/Navigation/Mobile/MobileDateScrubber.tsx
@@ -7,8 +7,8 @@ import formatSliderValueForLabel from '@/utils/dateFormatting/formatSliderValueF
 import CustomDateSlider from '@/components/Navigation/CustomDateSlider';
 import useGlassTokens from '@/hooks/useGlassTokens';
 import {
-  monthMarks,
-  monthlyMarks,
+  monthMarksShort,
+  monthlyMarksShort,
   MOBILE_BAR_INSET_PX,
   MOBILE_BAR_RADIUS_PX,
   MOBILE_SCRUBBER_BOTTOM_PX,
@@ -50,7 +50,7 @@ const MobileDateScrubber: FC<MobileDateScrubberProps> = ({
     onDateChange(newDate);
   };
 
-  const marks = isMonthly ? [...monthlyMarks] : [...monthMarks];
+  const marks = isMonthly ? [...monthlyMarksShort] : [...monthMarksShort];
   const maxValue = isMonthly ? 12 : 365;
 
   const labelValue = previewValue ?? sliderValue;

--- a/client/src/components/Shared/WelcomeModal.tsx
+++ b/client/src/components/Shared/WelcomeModal.tsx
@@ -42,10 +42,6 @@ export const WelcomeModal = () => {
           inaccuracies might occur!
         </Text>
         <Text ta="center">
-          Furthermore, I'm still developing this app, so aesthetics and
-          functionality are projected to change a lot in the near future.
-        </Text>
-        <Text ta="center">
           If you have any nice ideas of how to make the app better, please
           submit the feedback via the button at the top. I'll get it in my
           email.

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -457,5 +457,8 @@ export const MOBILE_ICON_BUTTON_SIZE_PX = 36;
 // = MOBILE_TOP_BAR_TOP_PX (16) + MOBILE_BAR_HEIGHT_PX (52) + 12px gap.
 export const MOBILE_BELOW_BAR_TOP_PX = 80;
 
+// Persistent mobile date scrubber: distance from viewport bottom.
+export const MOBILE_SCRUBBER_BOTTOM_PX = 16;
+
 // Desktop top offset for floating chrome elements (legend, loader).
 export const DESKTOP_TOP_OFFSET_PX = 16;

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -301,19 +301,19 @@ export const monthMarks = [
 ];
 
 // Mobile date scrubber marks: tick for every month, text label only at the
-// quarter starts (Jan/Apr/Jul/Oct) — empty `label` renders a small tick.
+// quarter midpoints (Feb/May/Aug/Nov) — empty `label` renders a small tick.
 export const monthMarksMobile = [
-  { value: 1, label: 'Jan' },
-  { value: 32, label: '' },
+  { value: 1, label: '' },
+  { value: 32, label: 'Feb' },
   { value: 60, label: '' },
-  { value: 91, label: 'Apr' },
-  { value: 121, label: '' },
+  { value: 91, label: '' },
+  { value: 121, label: 'May' },
   { value: 152, label: '' },
-  { value: 182, label: 'Jul' },
-  { value: 213, label: '' },
+  { value: 182, label: '' },
+  { value: 213, label: 'Aug' },
   { value: 244, label: '' },
-  { value: 274, label: 'Oct' },
-  { value: 305, label: '' },
+  { value: 274, label: '' },
+  { value: 305, label: 'Nov' },
   { value: 335, label: '' },
 ];
 
@@ -334,19 +334,19 @@ export const monthlyMarks = [
 ] as const;
 
 // Mobile monthly marks: tick for every month, text label only at the quarter
-// starts (Jan/Apr/Jul/Oct) — empty `label` renders a small tick.
+// midpoints (Feb/May/Aug/Nov) — empty `label` renders a small tick.
 export const monthlyMarksMobile = [
-  { value: 1, label: 'Jan' },
-  { value: 2, label: '' },
+  { value: 1, label: '' },
+  { value: 2, label: 'Feb' },
   { value: 3, label: '' },
-  { value: 4, label: 'Apr' },
-  { value: 5, label: '' },
+  { value: 4, label: '' },
+  { value: 5, label: 'May' },
   { value: 6, label: '' },
-  { value: 7, label: 'Jul' },
-  { value: 8, label: '' },
+  { value: 7, label: '' },
+  { value: 8, label: 'Aug' },
   { value: 9, label: '' },
-  { value: 10, label: 'Oct' },
-  { value: 11, label: '' },
+  { value: 10, label: '' },
+  { value: 11, label: 'Nov' },
   { value: 12, label: '' },
 ];
 

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -300,21 +300,21 @@ export const monthMarks = [
   { value: 335, label: 'Dec' },
 ];
 
-// Single-letter month marks used on the mobile date scrubber where the full
-// 3-letter labels overlap on phone-width tracks.
-export const monthMarksShort = [
-  { value: 1, label: 'J' },
-  { value: 32, label: 'F' },
-  { value: 60, label: 'M' },
-  { value: 91, label: 'A' },
-  { value: 121, label: 'M' },
-  { value: 152, label: 'J' },
-  { value: 182, label: 'J' },
-  { value: 213, label: 'A' },
-  { value: 244, label: 'S' },
-  { value: 274, label: 'O' },
-  { value: 305, label: 'N' },
-  { value: 335, label: 'D' },
+// Mobile date scrubber marks: tick for every month, text label only at the
+// quarter starts (Jan/Apr/Jul/Oct) — empty `label` renders a small tick.
+export const monthMarksMobile = [
+  { value: 1, label: 'Jan' },
+  { value: 32, label: '' },
+  { value: 60, label: '' },
+  { value: 91, label: 'Apr' },
+  { value: 121, label: '' },
+  { value: 152, label: '' },
+  { value: 182, label: 'Jul' },
+  { value: 213, label: '' },
+  { value: 244, label: '' },
+  { value: 274, label: 'Oct' },
+  { value: 305, label: '' },
+  { value: 335, label: '' },
 ];
 
 // monthly marks for date slider when in monthly mode (sunshine data)
@@ -333,21 +333,21 @@ export const monthlyMarks = [
   { value: 12, label: 'Dec' },
 ] as const;
 
-// Single-letter monthly marks used on the mobile date scrubber where the full
-// 3-letter labels overlap on phone-width tracks.
-export const monthlyMarksShort = [
-  { value: 1, label: 'J' },
-  { value: 2, label: 'F' },
-  { value: 3, label: 'M' },
-  { value: 4, label: 'A' },
-  { value: 5, label: 'M' },
-  { value: 6, label: 'J' },
-  { value: 7, label: 'J' },
-  { value: 8, label: 'A' },
-  { value: 9, label: 'S' },
-  { value: 10, label: 'O' },
-  { value: 11, label: 'N' },
-  { value: 12, label: 'D' },
+// Mobile monthly marks: tick for every month, text label only at the quarter
+// starts (Jan/Apr/Jul/Oct) — empty `label` renders a small tick.
+export const monthlyMarksMobile = [
+  { value: 1, label: 'Jan' },
+  { value: 2, label: '' },
+  { value: 3, label: '' },
+  { value: 4, label: 'Apr' },
+  { value: 5, label: '' },
+  { value: 6, label: '' },
+  { value: 7, label: 'Jul' },
+  { value: 8, label: '' },
+  { value: 9, label: '' },
+  { value: 10, label: 'Oct' },
+  { value: 11, label: '' },
+  { value: 12, label: '' },
 ];
 
 // ============================================================================

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -300,6 +300,23 @@ export const monthMarks = [
   { value: 335, label: 'Dec' },
 ];
 
+// Single-letter month marks used on the mobile date scrubber where the full
+// 3-letter labels overlap on phone-width tracks.
+export const monthMarksShort = [
+  { value: 1, label: 'J' },
+  { value: 32, label: 'F' },
+  { value: 60, label: 'M' },
+  { value: 91, label: 'A' },
+  { value: 121, label: 'M' },
+  { value: 152, label: 'J' },
+  { value: 182, label: 'J' },
+  { value: 213, label: 'A' },
+  { value: 244, label: 'S' },
+  { value: 274, label: 'O' },
+  { value: 305, label: 'N' },
+  { value: 335, label: 'D' },
+];
+
 // monthly marks for date slider when in monthly mode (sunshine data)
 export const monthlyMarks = [
   { value: 1, label: 'Jan' },
@@ -315,6 +332,23 @@ export const monthlyMarks = [
   { value: 11, label: 'Nov' },
   { value: 12, label: 'Dec' },
 ] as const;
+
+// Single-letter monthly marks used on the mobile date scrubber where the full
+// 3-letter labels overlap on phone-width tracks.
+export const monthlyMarksShort = [
+  { value: 1, label: 'J' },
+  { value: 2, label: 'F' },
+  { value: 3, label: 'M' },
+  { value: 4, label: 'A' },
+  { value: 5, label: 'M' },
+  { value: 6, label: 'J' },
+  { value: 7, label: 'J' },
+  { value: 8, label: 'A' },
+  { value: 9, label: 'S' },
+  { value: 10, label: 'O' },
+  { value: 11, label: 'N' },
+  { value: 12, label: 'D' },
+];
 
 // ============================================================================
 // CITY POPUP RIBBON CONSTANTS

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -273,6 +273,10 @@ export const MONTH_FIELDS: Record<number, keyof SunshineData> = {
 // custom date slider thumb dimensions for positioning calculations
 export const SLIDER_THUMB_WIDTH = 14;
 
+// Tick mark dimensions rendered by SliderMarks beneath each mark value.
+export const SLIDER_MARK_TICK_WIDTH_PX = 1;
+export const SLIDER_MARK_TICK_HEIGHT_PX = 6;
+
 // days in each month (using 28.25 for February to account for leap years)
 export const DAYS_IN_MONTH = [
   31, 28.25, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -209,7 +209,13 @@ const MapPage: FC = () => {
         />
       )}
 
-      {isMobileOrSmall && <MobileDateScrubber selectedDate={selectedDate} />}
+      {isMobileOrSmall && (
+        <MobileDateScrubber
+          selectedDate={selectedDate}
+          onDateChange={handleDateChange}
+          isMonthly={isSunshineSelected}
+        />
+      )}
 
       {!isMobileOrSmall && (
         <div className="absolute bottom-4 right-4 z-20 flex items-center gap-2">

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -165,26 +165,27 @@ describe('MobileDateScrubber', () => {
     expect(screen.getByTestId('mock-custom-date-slider')).toBeInTheDocument();
   });
 
-  it('passes single-letter month marks to the slider in daily mode', () => {
+  it('passes 12 marks with text labels only at the quarter starts in daily mode', () => {
     render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
-    const labels = captured.props?.marks.map((m) => m.label);
-    expect(labels).toEqual([
-      'J',
-      'F',
-      'M',
-      'A',
-      'M',
-      'J',
-      'J',
-      'A',
-      'S',
-      'O',
-      'N',
-      'D',
+    const marks = captured.props?.marks ?? [];
+    expect(marks).toHaveLength(12);
+    expect(marks.map((m) => m.label)).toEqual([
+      'Jan',
+      '',
+      '',
+      'Apr',
+      '',
+      '',
+      'Jul',
+      '',
+      '',
+      'Oct',
+      '',
+      '',
     ]);
   });
 
-  it('passes single-letter month marks to the slider in monthly mode', () => {
+  it('passes 12 marks with text labels only at the quarter starts in monthly mode', () => {
     render(
       <MobileDateScrubber
         selectedDate="07-15"
@@ -192,20 +193,24 @@ describe('MobileDateScrubber', () => {
         isMonthly
       />
     );
-    const labels = captured.props?.marks.map((m) => m.label);
-    expect(labels).toEqual([
-      'J',
-      'F',
-      'M',
-      'A',
-      'M',
-      'J',
-      'J',
-      'A',
-      'S',
-      'O',
-      'N',
-      'D',
+    const marks = captured.props?.marks ?? [];
+    expect(marks).toHaveLength(12);
+    expect(marks.map((m) => m.label)).toEqual([
+      'Jan',
+      '',
+      '',
+      'Apr',
+      '',
+      '',
+      'Jul',
+      '',
+      '',
+      'Oct',
+      '',
+      '',
+    ]);
+    expect(marks.map((m) => m.value)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
     ]);
   });
 });

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -165,27 +165,27 @@ describe('MobileDateScrubber', () => {
     expect(screen.getByTestId('mock-custom-date-slider')).toBeInTheDocument();
   });
 
-  it('passes 12 marks with text labels only at the quarter starts in daily mode', () => {
+  it('passes 12 marks with text labels only at the quarter midpoints in daily mode', () => {
     render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
     const marks = captured.props?.marks ?? [];
     expect(marks).toHaveLength(12);
     expect(marks.map((m) => m.label)).toEqual([
-      'Jan',
+      '',
+      'Feb',
       '',
       '',
-      'Apr',
+      'May',
       '',
       '',
-      'Jul',
+      'Aug',
       '',
       '',
-      'Oct',
-      '',
+      'Nov',
       '',
     ]);
   });
 
-  it('passes 12 marks with text labels only at the quarter starts in monthly mode', () => {
+  it('passes 12 marks with text labels only at the quarter midpoints in monthly mode', () => {
     render(
       <MobileDateScrubber
         selectedDate="07-15"
@@ -196,17 +196,17 @@ describe('MobileDateScrubber', () => {
     const marks = captured.props?.marks ?? [];
     expect(marks).toHaveLength(12);
     expect(marks.map((m) => m.label)).toEqual([
-      'Jan',
+      '',
+      'Feb',
       '',
       '',
-      'Apr',
+      'May',
       '',
       '',
-      'Jul',
+      'Aug',
       '',
       '',
-      'Oct',
-      '',
+      'Nov',
       '',
     ]);
     expect(marks.map((m) => m.value)).toEqual([

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -150,11 +150,7 @@ describe('MobileDateScrubber', () => {
 
   it('slides offscreen when hidden=true', () => {
     render(
-      <MobileDateScrubber
-        selectedDate="0410"
-        onDateChange={vi.fn()}
-        hidden
-      />
+      <MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} hidden />
     );
     const root = screen.getByTestId('mobile-date-scrubber');
     expect(root.style.transform).toBe('translateY(120%)');

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -1,22 +1,166 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
 import { render, screen } from '@/test-utils';
 import MobileDateScrubber from '@/components/Navigation/Mobile/MobileDateScrubber';
 
+interface CapturedSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  onValuePreview?: (value: number) => void;
+  min: number;
+  max: number;
+  isMonthly?: boolean;
+}
+
+const captured: { props: CapturedSliderProps | null } = { props: null };
+
+vi.mock('@/components/Navigation/CustomDateSlider', () => ({
+  default: (props: CapturedSliderProps) => {
+    captured.props = props;
+    return <div data-testid="mock-custom-date-slider" />;
+  },
+}));
+
 describe('MobileDateScrubber', () => {
-  it('renders the selected date', () => {
-    render(<MobileDateScrubber selectedDate="05-15" />);
-    expect(screen.getByText('DATE: 05-15')).toBeInTheDocument();
+  beforeEach(() => {
+    captured.props = null;
+  });
+
+  it('renders the formatted daily label for an MMDD selectedDate', () => {
+    render(<MobileDateScrubber selectedDate="0810" onDateChange={vi.fn()} />);
+    expect(screen.getByText('Aug. 10')).toBeInTheDocument();
+  });
+
+  it('renders Jan. 1 / Dec. 31 daily boundaries correctly', () => {
+    const { rerender } = render(
+      <MobileDateScrubber selectedDate="0101" onDateChange={vi.fn()} />
+    );
+    expect(screen.getByText('Jan. 1')).toBeInTheDocument();
+
+    rerender(<MobileDateScrubber selectedDate="1231" onDateChange={vi.fn()} />);
+    expect(screen.getByText('Dec. 31')).toBeInTheDocument();
+  });
+
+  it('renders the monthly label when isMonthly is true', () => {
+    render(
+      <MobileDateScrubber
+        selectedDate="07-15"
+        onDateChange={vi.fn()}
+        isMonthly
+      />
+    );
+    expect(screen.getByText('Jul')).toBeInTheDocument();
+  });
+
+  it('passes the day-of-year as slider value in daily mode', () => {
+    render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
+    // Apr 10 = 31 + 28 + 31 + 10 = 100
+    expect(captured.props?.value).toBe(100);
+    expect(captured.props?.min).toBe(1);
+    expect(captured.props?.max).toBe(365);
+    expect(captured.props?.isMonthly).toBe(false);
+  });
+
+  it('passes the month index as slider value in monthly mode', () => {
+    render(
+      <MobileDateScrubber
+        selectedDate="07-15"
+        onDateChange={vi.fn()}
+        isMonthly
+      />
+    );
+    expect(captured.props?.value).toBe(7);
+    expect(captured.props?.isMonthly).toBe(true);
+  });
+
+  it('does not call onDateChange while only onValuePreview is invoked', () => {
+    const onDateChange = vi.fn();
+    render(
+      <MobileDateScrubber selectedDate="0410" onDateChange={onDateChange} />
+    );
+
+    act(() => {
+      captured.props?.onValuePreview?.(120);
+      captured.props?.onValuePreview?.(140);
+      captured.props?.onValuePreview?.(160);
+    });
+
+    expect(onDateChange).not.toHaveBeenCalled();
+  });
+
+  it('updates the trailing label live during onValuePreview without commit', () => {
+    const onDateChange = vi.fn();
+    render(
+      <MobileDateScrubber selectedDate="0410" onDateChange={onDateChange} />
+    );
+
+    expect(screen.getByText('Apr. 10')).toBeInTheDocument();
+
+    // Day-of-year 213 = Aug 1
+    act(() => {
+      captured.props?.onValuePreview?.(213);
+    });
+    expect(screen.getByText('Aug. 1')).toBeInTheDocument();
+    expect(onDateChange).not.toHaveBeenCalled();
+  });
+
+  it('commits exactly once with the formatted MMDD date when onChange fires', () => {
+    const onDateChange = vi.fn();
+    render(
+      <MobileDateScrubber selectedDate="0410" onDateChange={onDateChange} />
+    );
+
+    captured.props?.onChange(213);
+
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+    expect(onDateChange).toHaveBeenCalledWith('0801');
+  });
+
+  it('commits the MM-15 date when onChange fires in monthly mode', () => {
+    const onDateChange = vi.fn();
+    render(
+      <MobileDateScrubber
+        selectedDate="07-15"
+        onDateChange={onDateChange}
+        isMonthly
+      />
+    );
+
+    captured.props?.onChange(11);
+
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+    expect(onDateChange).toHaveBeenCalledWith('11-15');
+  });
+
+  it('positions the bar fixed at the bottom of the viewport with the configured insets', () => {
+    render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
+    const root = screen.getByTestId('mobile-date-scrubber');
+    expect(root.style.position).toBe('fixed');
+    expect(root.style.bottom).toBe('16px');
+    expect(root.style.left).toBe('12px');
+    expect(root.style.right).toBe('12px');
   });
 
   it('defaults to visible (translateY(0))', () => {
-    render(<MobileDateScrubber selectedDate="05-15" />);
-    const scrubber = screen.getByText('DATE: 05-15').closest('div');
-    expect(scrubber?.style.transform).toBe('translateY(0)');
+    render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
+    const root = screen.getByTestId('mobile-date-scrubber');
+    expect(root.style.transform).toBe('translateY(0)');
   });
 
   it('slides offscreen when hidden=true', () => {
-    render(<MobileDateScrubber selectedDate="05-15" hidden />);
-    const scrubber = screen.getByText('DATE: 05-15').closest('div');
-    expect(scrubber?.style.transform).toBe('translateY(120%)');
+    render(
+      <MobileDateScrubber
+        selectedDate="0410"
+        onDateChange={vi.fn()}
+        hidden
+      />
+    );
+    const root = screen.getByTestId('mobile-date-scrubber');
+    expect(root.style.transform).toBe('translateY(120%)');
+  });
+
+  it('renders the CustomDateSlider', () => {
+    render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
+    expect(screen.getByTestId('mock-custom-date-slider')).toBeInTheDocument();
   });
 });

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
 import { render, screen } from '@/test-utils';
 import MobileDateScrubber from '@/components/Navigation/Mobile/MobileDateScrubber';
+import { MOBILE_SCRUBBER_BOTTOM_PX, MOBILE_BAR_INSET_PX } from '@/const';
 
 interface CapturedSliderProps {
   value: number;
@@ -137,9 +138,9 @@ describe('MobileDateScrubber', () => {
     render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
     const root = screen.getByTestId('mobile-date-scrubber');
     expect(root.style.position).toBe('fixed');
-    expect(root.style.bottom).toBe('16px');
-    expect(root.style.left).toBe('12px');
-    expect(root.style.right).toBe('12px');
+    expect(root.style.bottom).toBe(`${MOBILE_SCRUBBER_BOTTOM_PX}px`);
+    expect(root.style.left).toBe(`${MOBILE_BAR_INSET_PX}px`);
+    expect(root.style.right).toBe(`${MOBILE_BAR_INSET_PX}px`);
   });
 
   it('defaults to visible (translateY(0))', () => {

--- a/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
+++ b/client/src/tests/components/Navigation/Mobile/MobileDateScrubber.test.tsx
@@ -9,6 +9,7 @@ interface CapturedSliderProps {
   onValuePreview?: (value: number) => void;
   min: number;
   max: number;
+  marks: Array<{ value: number; label: string }>;
   isMonthly?: boolean;
 }
 
@@ -162,5 +163,49 @@ describe('MobileDateScrubber', () => {
   it('renders the CustomDateSlider', () => {
     render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
     expect(screen.getByTestId('mock-custom-date-slider')).toBeInTheDocument();
+  });
+
+  it('passes single-letter month marks to the slider in daily mode', () => {
+    render(<MobileDateScrubber selectedDate="0410" onDateChange={vi.fn()} />);
+    const labels = captured.props?.marks.map((m) => m.label);
+    expect(labels).toEqual([
+      'J',
+      'F',
+      'M',
+      'A',
+      'M',
+      'J',
+      'J',
+      'A',
+      'S',
+      'O',
+      'N',
+      'D',
+    ]);
+  });
+
+  it('passes single-letter month marks to the slider in monthly mode', () => {
+    render(
+      <MobileDateScrubber
+        selectedDate="07-15"
+        onDateChange={vi.fn()}
+        isMonthly
+      />
+    );
+    const labels = captured.props?.marks.map((m) => m.label);
+    expect(labels).toEqual([
+      'J',
+      'F',
+      'M',
+      'A',
+      'M',
+      'J',
+      'J',
+      'A',
+      'S',
+      'O',
+      'N',
+      'D',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the date stub on mobile with a glass-surface bar that wraps \`CustomDateSlider\` directly.

- Trailing label updates **live during drag** via \`onValuePreview\` (no commit, no refetch).
- \`onDateChange\` commits **exactly once on pointer-release** — apply-on-release, no Apply button. (\`useMove\`'s \`onScrubEnd\` already encodes this; no extra plumbing.)
- Supports both daily (MMDD ↔ day-of-year, 1–365) and monthly (MM-15 ↔ month index, 1–12) modes; \`pages/map.tsx\` mobile branch passes \`onDateChange={handleDateChange}\` and \`isMonthly={isSunshineSelected}\`.
- Mobile scrubber marks: tick for every month, text label only at the **quarter midpoints (Feb / May / Aug / Nov)**. Quarter-start labels (Jan / Apr / Jul / Oct) were visually awkward because Jan sits flush at the left edge; midpoints center the labels better within each quarter's track space.
- Desktop unchanged — \`TopCommandBar\` + \`DateSliderWrapper\` untouched.

### SliderMarks fix (desktop + mobile)

\`SliderMarks\` previously rendered a tick **or** a label — a non-empty label suppressed the tick entirely, so labeled months had no visual tick on either the mobile scrubber or the desktop date slider. The component now always renders a tick, with the label stacked below it when present.

This is PR 2 of the mobile-layout plan. PR #122 added the breakpoint primitives; PR #123 added the top bar + hamburger sheet; this PR adds the persistent bottom date scrubber. (Task 5 from the original plan was folded into Task 4 — there is no separate expanded sheet, the bar IS the picker.)

## Plan deviations (intentional)

- Skipped \`MOBILE_SCRUBBER_THUMB_SIZE_PX = 18\` from the plan's "Files" list — preferred-path direct reuse of \`CustomDateSlider\` keeps the existing \`SLIDER_THUMB_WIDTH = 14\` constant; adding an unused constant would be clutter.
- \`hidden?: boolean\` prop is in the API and tested, but \`pages/map.tsx\` doesn't pass it yet — drawer-coordination wires up in Task 6 once \`useAppStore.isCityDrawerOpen\` exists.

## Test plan

- [x] Unit tests for \`MobileDateScrubber\` — daily/monthly label rendering, Jan 1 / Dec 31 boundaries, slider value mapping, no-commit-during-\`onValuePreview\`, live label update during preview, single-commit-on-\`onChange\` with correct date format (MMDD daily / MM-15 monthly), fixed positioning, translateY default + hidden, \`CustomDateSlider\` mount, and mark label layout (Feb/May/Aug/Nov labeled, all others tick-only).
- [x] Full suite: 848/848 passing.
- [x] \`tsc --noEmit\` clean.
- [x] Manual: drag the scrubber on a real phone, confirm date label live-updates, confirm map only refetches on release (network panel shows \`weatherByDateAndBounds\` firing once on pointer-up, not during drag).
- [x] Manual: switch to Sunshine mode (monthly), confirm scrubber re-binds to month index 1–12 with month abbreviation labels.
- [x] Manual: verify desktop date slider now shows tick marks on labeled months (Jan–Dec all have ticks; labeled months have text below the tick).