### PR TITLE
feat(mobile): MobileCityDrawer + WorldMap breakpoint switch

### DIFF
--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -1,0 +1,478 @@
+import { ActionIcon, useMantineColorScheme } from '@mantine/core';
+import { useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
+import { IconPlus, IconX } from '@tabler/icons-react';
+
+import useWeatherDataForCity from '@/api/dates/useWeatherDataForCity';
+import useSunshineDataForCity from '@/api/dates/useSunshineDataForCity';
+import useWeeklyWeatherForCity from '@/api/dates/useWeeklyWeatherForCity';
+import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
+import TodayReadout from '@/components/CityPopup/Ribbon/TodayReadout';
+import DataChartTabs from '@/components/CityPopup/DataChartTabs';
+import MobileTabBar from '@/components/CityPopup/Mobile/MobileTabBar';
+import MobileDetailsList from '@/components/CityPopup/Mobile/MobileDetailsList';
+import { useRibbonStats } from '@/components/CityPopup/hooks/useRibbonStats';
+import { useAppStore } from '@/stores/useAppStore';
+import { toTitleCase } from '@/utils/dataFormatting/toTitleCase';
+import { getSunshinePercent } from '@/utils/dataFormatting/getSunshinePercent';
+import { hasSunshineData } from '@/utils/dataFormatting/hasSunshineData';
+import { normalizeRainyDays } from '@/utils/dataFormatting/normalizeRainyDays';
+import { normalizeWeekPrecip } from '@/utils/dataFormatting/normalizeWeekPrecip';
+import { dateToWeekOfYear } from '@/utils/dateFormatting/dateToWeekOfYear';
+import { extractMonthDay } from '@/utils/dateFormatting/extractMonthDay';
+import { extractMonthFromDate } from '@/utils/dateFormatting/extractMonthFromDate';
+import { isWeatherData } from '@/utils/typeGuards';
+import { DataType } from '@/types/mapTypes';
+import { MobileTab } from '@/types/mobileTabType';
+import {
+  CITY1_PRIMARY_COLOR,
+  MONTH_MIDPOINT_DAY,
+  STATE_ABBREVIATION_MAX_LENGTH,
+  CITY2_PRIMARY_COLOR,
+  MOBILE_DRAWER_HEIGHT_CAP_PX,
+  MOBILE_DRAWER_HEIGHT_VH,
+  MOBILE_DRAWER_HEADER_PX,
+  MOBILE_DRAWER_CHART_MIN_PX,
+  MOBILE_DRAWER_BOTTOM_PAD_PX,
+  MOBILE_DRAWER_DRAG_HANDLE_W_PX,
+  MOBILE_DRAWER_DRAG_HANDLE_H_PX,
+  MOBILE_DRAWER_RADIUS_PX,
+  MOBILE_DRAWER_DISMISS_DRAG_FRACTION,
+  MOBILE_DRAWER_DISMISS_VELOCITY_PX_PER_S,
+  MOBILE_DRAWER_DISMISS_VELOCITY_MIN_DT_MS,
+  MOBILE_DRAWER_DISMISS_ANIM_MS,
+  MS_PER_SECOND,
+} from '@/const';
+import { appColors } from '@/theme';
+
+import type { CityPopupProps } from '@/types/mapTypes';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+import type { TodayValuesByTab } from '@/types/cityPopupTypes';
+
+const dataTypeToMobileTab = (d: DataType): MobileTab => {
+  if (d === DataType.Sunshine) return MobileTab.Sunshine;
+  if (d === DataType.Precip) return MobileTab.Precip;
+  return MobileTab.Temperature;
+};
+
+const isChartTab = (t: MobileTab): t is Exclude<MobileTab, MobileTab.Details> =>
+  t !== MobileTab.Details;
+
+const mobileTabToDataType = (t: MobileTab): DataType => {
+  if (t === MobileTab.Sunshine) return DataType.Sunshine;
+  if (t === MobileTab.Precip) return DataType.Precip;
+  return DataType.Temperature;
+};
+
+const MobileCityDrawer = ({
+  city,
+  onClose,
+  selectedMonth,
+  selectedDate,
+  dataType,
+}: CityPopupProps) => {
+  const { colorScheme } = useMantineColorScheme();
+  const setIsCityDrawerOpen = useAppStore((s) => s.setIsCityDrawerOpen);
+
+  const [comparisonCity, setComparisonCity] =
+    useState<SearchCitiesResult | null>(null);
+  const [tab, setTab] = useState<MobileTab>(dataTypeToMobileTab(dataType));
+  const [dragOffset, setDragOffset] = useState<number | null>(null);
+  const [isDismissing, setIsDismissing] = useState(false);
+
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const dragStartRef = useRef<{ y: number; t: number } | null>(null);
+  const lastPointerRef = useRef<{ y: number; t: number } | null>(null);
+
+  useEffect(() => {
+    setIsCityDrawerOpen(true);
+    return () => setIsCityDrawerOpen(false);
+  }, [setIsCityDrawerOpen]);
+
+  useEffect(() => {
+    setTab(dataTypeToMobileTab(dataType));
+  }, [dataType]);
+
+  const cityAsWeather = city && isWeatherData(city) ? city : null;
+  const cityAsSunshine = city && !isWeatherData(city) ? city : null;
+
+  const monthToUse =
+    selectedMonth ??
+    extractMonthFromDate(cityAsWeather?.date) ??
+    new Date().getMonth() + 1;
+
+  const dateToUse = useMemo(() => {
+    if (selectedDate) return selectedDate;
+    if (cityAsWeather?.date) return cityAsWeather.date;
+    return `${monthToUse.toString().padStart(2, '0')}-${MONTH_MIDPOINT_DAY.toString().padStart(2, '0')}`;
+  }, [selectedDate, cityAsWeather, monthToUse]);
+
+  const shouldFetchWeather = !!city;
+
+  const { weatherData } = useWeatherDataForCity({
+    cityName: city?.city ?? null,
+    lat: city?.lat ?? null,
+    long: city?.long ?? null,
+    selectedDate: dateToUse,
+    skipFetch: !shouldFetchWeather,
+  });
+
+  const shouldFetchSunshine =
+    !cityAsSunshine && monthToUse >= 1 && monthToUse <= 12;
+
+  const { sunshineData, sunshineLoading, sunshineError } =
+    useSunshineDataForCity({
+      cityName: city?.city ?? null,
+      lat: city?.lat ?? null,
+      long: city?.long ?? null,
+      skipFetch: !shouldFetchSunshine,
+    });
+
+  const {
+    weeklyWeatherData,
+    loading: weeklyWeatherLoading,
+    error: weeklyWeatherError,
+  } = useWeeklyWeatherForCity({
+    cityName: city?.city ?? null,
+    lat: city?.lat ?? null,
+    long: city?.long ?? null,
+    skipFetch: !city,
+  });
+
+  const monthDayOnly = useMemo(() => extractMonthDay(dateToUse), [dateToUse]);
+
+  const { weatherData: comparisonWeatherData } = useWeatherDataForCity({
+    cityName: comparisonCity?.name ?? null,
+    lat: comparisonCity?.lat ?? null,
+    long: comparisonCity?.long ?? null,
+    selectedDate: monthDayOnly,
+    skipFetch: !comparisonCity,
+  });
+
+  const { weeklyWeatherData: comparisonWeeklyWeatherData } =
+    useWeeklyWeatherForCity({
+      cityName: comparisonCity?.name ?? null,
+      lat: comparisonCity?.lat ?? null,
+      long: comparisonCity?.long ?? null,
+      skipFetch: !comparisonCity,
+    });
+
+  const { sunshineData: comparisonSunshineData } = useSunshineDataForCity({
+    cityName: comparisonCity?.name ?? null,
+    lat: comparisonCity?.lat ?? null,
+    long: comparisonCity?.long ?? null,
+    skipFetch: !comparisonCity,
+  });
+
+  const displayWeatherData = weatherData ?? cityAsWeather;
+  const displaySunshineData = cityAsSunshine ?? sunshineData;
+
+  const primaryHasSunshine = hasSunshineData(displaySunshineData);
+  const comparisonHasSunshine = hasSunshineData(comparisonSunshineData);
+
+  const sunshineTabAvailable =
+    sunshineLoading || primaryHasSunshine || comparisonHasSunshine;
+
+  const availableTabs = useMemo<ReadonlyArray<MobileTab>>(
+    () =>
+      sunshineTabAvailable
+        ? [
+            MobileTab.Temperature,
+            MobileTab.Sunshine,
+            MobileTab.Precip,
+            MobileTab.Details,
+          ]
+        : [MobileTab.Temperature, MobileTab.Precip, MobileTab.Details],
+    [sunshineTabAvailable]
+  );
+
+  const visibleTab = availableTabs.includes(tab)
+    ? tab
+    : (availableTabs[0] ?? MobileTab.Temperature);
+
+  const stats = useRibbonStats({
+    basePopulation: city?.population ?? null,
+    comparisonPopulation: comparisonCity?.population ?? null,
+    baseLat: city?.lat ?? null,
+    baseLong: city?.long ?? null,
+    comparisonLat: comparisonCity?.lat ?? null,
+    comparisonLong: comparisonCity?.long ?? null,
+    displayWeatherData,
+    comparisonWeatherData,
+    displaySunshineData,
+    comparisonSunshineData,
+    weeklyWeatherData,
+    comparisonWeeklyWeatherData,
+  });
+
+  const todayValuesByTab = useMemo<TodayValuesByTab>(() => {
+    const selectedWeek = dateToWeekOfYear(dateToUse);
+    const findWeek = (data: typeof weeklyWeatherData) =>
+      selectedWeek === null
+        ? null
+        : (data?.weeklyData.find((w) => w.week === selectedWeek) ?? null);
+
+    const w1 = findWeek(weeklyWeatherData);
+    const w2 = findWeek(comparisonWeeklyWeatherData);
+
+    return {
+      [DataType.Temperature]: {
+        c1: displayWeatherData?.avgTemperature ?? null,
+        c2: comparisonWeatherData?.avgTemperature ?? null,
+      },
+      [DataType.Sunshine]: {
+        c1: getSunshinePercent(displaySunshineData, monthToUse, city?.lat),
+        c2: getSunshinePercent(
+          comparisonSunshineData,
+          monthToUse,
+          comparisonCity?.lat
+        ),
+      },
+      [DataType.Precip]: {
+        c1: normalizeWeekPrecip(w1),
+        c2: normalizeWeekPrecip(w2),
+        subC1: normalizeRainyDays(w1),
+        subC2: normalizeRainyDays(w2),
+      },
+    };
+  }, [
+    dateToUse,
+    monthToUse,
+    city?.lat,
+    comparisonCity?.lat,
+    displayWeatherData,
+    comparisonWeatherData,
+    displaySunshineData,
+    comparisonSunshineData,
+    weeklyWeatherData,
+    comparisonWeeklyWeatherData,
+  ]);
+
+  const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const now = performance.now();
+    dragStartRef.current = { y: e.clientY, t: now };
+    lastPointerRef.current = { y: e.clientY, t: now };
+    setDragOffset(0);
+  };
+
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!dragStartRef.current) return;
+    const dy = Math.max(0, e.clientY - dragStartRef.current.y);
+    lastPointerRef.current = { y: e.clientY, t: performance.now() };
+    setDragOffset(dy);
+  };
+
+  const handlePointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    if (!dragStartRef.current) return;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+
+    const finalDy = Math.max(0, e.clientY - dragStartRef.current.y);
+    const drawerHeight = drawerRef.current?.getBoundingClientRect().height ?? 0;
+    const distanceThreshold =
+      drawerHeight * MOBILE_DRAWER_DISMISS_DRAG_FRACTION;
+
+    const last = lastPointerRef.current;
+    const dt = last ? last.t - dragStartRef.current.t : 0;
+    const velocityPxPerS =
+      dt >= MOBILE_DRAWER_DISMISS_VELOCITY_MIN_DT_MS
+        ? (finalDy / dt) * MS_PER_SECOND
+        : 0;
+
+    dragStartRef.current = null;
+    lastPointerRef.current = null;
+
+    const shouldDismiss =
+      finalDy > distanceThreshold ||
+      velocityPxPerS > MOBILE_DRAWER_DISMISS_VELOCITY_PX_PER_S;
+
+    if (shouldDismiss) {
+      setIsDismissing(true);
+      window.setTimeout(() => {
+        onClose();
+      }, MOBILE_DRAWER_DISMISS_ANIM_MS);
+    } else {
+      setDragOffset(null);
+    }
+  };
+
+  if (!city) return null;
+
+  let cityAndCountry = city.city ? toTitleCase(city.city) : 'Unknown City';
+  if (city.state) {
+    const state =
+      city.state.length > STATE_ABBREVIATION_MAX_LENGTH
+        ? city.state.substring(0, STATE_ABBREVIATION_MAX_LENGTH) + '.'
+        : city.state;
+    cityAndCountry += `, ${toTitleCase(state)}`;
+  }
+  if (city.country) {
+    cityAndCountry += `, ${city.country}`;
+  }
+
+  const comparisonName = comparisonCity
+    ? [comparisonCity.name, comparisonCity.state, comparisonCity.country]
+        .filter(Boolean)
+        .join(', ')
+    : null;
+
+  const transformValue = isDismissing
+    ? 'translateY(100%)'
+    : dragOffset !== null
+      ? `translateY(${dragOffset}px)`
+      : 'translateY(0)';
+
+  const transitionValue =
+    dragOffset !== null && !isDismissing
+      ? 'none'
+      : `transform ${MOBILE_DRAWER_DISMISS_ANIM_MS}ms ease`;
+
+  const chartTabForDataChartTabs = isChartTab(visibleTab)
+    ? mobileTabToDataType(visibleTab)
+    : DataType.Temperature;
+
+  const todayPair = todayValuesByTab[chartTabForDataChartTabs];
+
+  return (
+    <div
+      ref={drawerRef}
+      data-testid="mobile-city-drawer"
+      className="fixed left-0 right-0 bottom-0 flex flex-col shadow-lg"
+      style={{
+        height: `min(${MOBILE_DRAWER_HEIGHT_VH}vh, ${MOBILE_DRAWER_HEIGHT_CAP_PX}px)`,
+        borderTopLeftRadius: MOBILE_DRAWER_RADIUS_PX,
+        borderTopRightRadius: MOBILE_DRAWER_RADIUS_PX,
+        backgroundColor:
+          colorScheme === 'dark'
+            ? appColors.dark.surface
+            : appColors.light.surface,
+        borderTop: '1px solid var(--mantine-color-default-border)',
+        pointerEvents: 'auto',
+        transform: transformValue,
+        transition: transitionValue,
+        zIndex: 50,
+      }}
+    >
+      <div
+        data-testid="mobile-drawer-drag-region"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        className="shrink-0 cursor-grab touch-none"
+        style={{
+          paddingTop: 8,
+          paddingBottom: 6,
+          minHeight: MOBILE_DRAWER_HEADER_PX,
+        }}
+      >
+        <div
+          aria-hidden="true"
+          className="mx-auto rounded-full bg-[var(--mantine-color-default-border)]"
+          style={{
+            width: MOBILE_DRAWER_DRAG_HANDLE_W_PX,
+            height: MOBILE_DRAWER_DRAG_HANDLE_H_PX,
+          }}
+        />
+        <header className="flex items-start justify-between gap-2 px-4 mt-1">
+          <div className="flex flex-col gap-1 min-w-0 flex-1">
+            <CityNameRow
+              color={CITY1_PRIMARY_COLOR}
+              name={cityAndCountry}
+              lat={city.lat ?? null}
+            />
+            {comparisonName ? (
+              <CityNameRow
+                color={CITY2_PRIMARY_COLOR}
+                name={comparisonName}
+                lat={comparisonCity?.lat ?? null}
+                actions={
+                  <button
+                    type="button"
+                    onClick={() => setComparisonCity(null)}
+                    aria-label="Remove comparison city"
+                    className="ml-0.5 text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] cursor-pointer shrink-0"
+                  >
+                    <IconX size={14} />
+                  </button>
+                }
+              />
+            ) : (
+              <button
+                type="button"
+                aria-label="Add comparison city"
+                className="flex items-center gap-2 cursor-pointer text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] transition-colors self-start"
+              >
+                <span
+                  className="w-2.5 h-2.5 rounded-full opacity-60"
+                  style={{ background: CITY2_PRIMARY_COLOR }}
+                />
+                <span className="text-[15px] font-bold font-[Outfit_Variable]">
+                  Compare
+                </span>
+                <IconPlus size={14} className="opacity-70" />
+              </button>
+            )}
+          </div>
+          <ActionIcon
+            onClick={onClose}
+            aria-label="Close"
+            variant="subtle"
+            size="md"
+          >
+            <IconX size={20} />
+          </ActionIcon>
+        </header>
+      </div>
+
+      <main
+        className="flex-1 min-h-0 flex flex-col px-4"
+        style={{ paddingBottom: MOBILE_DRAWER_BOTTOM_PAD_PX }}
+      >
+        {visibleTab === MobileTab.Details ? (
+          <MobileDetailsList stats={stats} hasComparison={!!comparisonCity} />
+        ) : (
+          <>
+            <div
+              className="flex-1 min-h-0"
+              style={{ minHeight: MOBILE_DRAWER_CHART_MIN_PX }}
+            >
+              <DataChartTabs
+                tab={chartTabForDataChartTabs}
+                displaySunshineData={displaySunshineData}
+                sunshineLoading={sunshineLoading}
+                sunshineError={!!sunshineError}
+                selectedMonth={monthToUse}
+                selectedDate={dateToUse}
+                weeklyWeatherData={weeklyWeatherData}
+                weeklyWeatherLoading={weeklyWeatherLoading}
+                weeklyWeatherError={!!weeklyWeatherError}
+                comparisonSunshineData={comparisonSunshineData}
+                comparisonWeeklyWeatherData={comparisonWeeklyWeatherData}
+              />
+            </div>
+            <div data-testid="mobile-drawer-today-readout" className="shrink-0">
+              <TodayReadout
+                tab={chartTabForDataChartTabs}
+                c1Value={todayPair.c1}
+                c2Value={todayPair.c2}
+                subC1Value={todayPair.subC1 ?? null}
+                subC2Value={todayPair.subC2 ?? null}
+                hasComparison={!!comparisonCity}
+                selectedDate={dateToUse}
+                hover={null}
+              />
+            </div>
+          </>
+        )}
+      </main>
+
+      <MobileTabBar
+        tab={visibleTab}
+        onTab={setTab}
+        availableTabs={availableTabs}
+      />
+    </div>
+  );
+};
+
+export default MobileCityDrawer;

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -21,6 +21,11 @@ import { dateToWeekOfYear } from '@/utils/dateFormatting/dateToWeekOfYear';
 import { extractMonthDay } from '@/utils/dateFormatting/extractMonthDay';
 import { extractMonthFromDate } from '@/utils/dateFormatting/extractMonthFromDate';
 import { isWeatherData } from '@/utils/typeGuards';
+import {
+  dataTypeToMobileTab,
+  isChartTab,
+  mobileTabToDataType,
+} from '@/components/CityPopup/Mobile/mobileDrawerHelpers';
 import { DataType } from '@/types/mapTypes';
 import { MobileTab } from '@/types/mobileTabType';
 import {
@@ -48,21 +53,6 @@ import type { CityPopupProps } from '@/types/mapTypes';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { TodayValuesByTab } from '@/types/cityPopupTypes';
 
-const dataTypeToMobileTab = (d: DataType): MobileTab => {
-  if (d === DataType.Sunshine) return MobileTab.Sunshine;
-  if (d === DataType.Precip) return MobileTab.Precip;
-  return MobileTab.Temperature;
-};
-
-const isChartTab = (t: MobileTab): t is Exclude<MobileTab, MobileTab.Details> =>
-  t !== MobileTab.Details;
-
-const mobileTabToDataType = (t: MobileTab): DataType => {
-  if (t === MobileTab.Sunshine) return DataType.Sunshine;
-  if (t === MobileTab.Precip) return DataType.Precip;
-  return DataType.Temperature;
-};
-
 const MobileCityDrawer = ({
   city,
   onClose,
@@ -82,10 +72,15 @@ const MobileCityDrawer = ({
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const dragStartRef = useRef<{ y: number; t: number } | null>(null);
   const lastPointerRef = useRef<{ y: number; t: number } | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setIsCityDrawerOpen(true);
-    return () => setIsCityDrawerOpen(false);
+    return () => {
+      setIsCityDrawerOpen(false);
+      if (dismissTimerRef.current !== null)
+        clearTimeout(dismissTimerRef.current);
+    };
   }, [setIsCityDrawerOpen]);
 
   useEffect(() => {
@@ -116,8 +111,7 @@ const MobileCityDrawer = ({
     skipFetch: !shouldFetchWeather,
   });
 
-  const shouldFetchSunshine =
-    !cityAsSunshine && monthToUse >= 1 && monthToUse <= 12;
+  const shouldFetchSunshine = !cityAsSunshine;
 
   const { sunshineData, sunshineLoading, sunshineError } =
     useSunshineDataForCity({
@@ -287,7 +281,7 @@ const MobileCityDrawer = ({
 
     if (shouldDismiss) {
       setIsDismissing(true);
-      window.setTimeout(() => {
+      dismissTimerRef.current = setTimeout(() => {
         onClose();
       }, MOBILE_DRAWER_DISMISS_ANIM_MS);
     } else {

--- a/client/src/components/CityPopup/Mobile/MobileDetailsList.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileDetailsList.tsx
@@ -6,7 +6,10 @@ interface MobileDetailsListProps {
   hasComparison: boolean;
 }
 
-const MobileDetailsList = ({ stats, hasComparison }: MobileDetailsListProps) => {
+const MobileDetailsList = ({
+  stats,
+  hasComparison,
+}: MobileDetailsListProps) => {
   return (
     <div
       data-testid="mobile-details-list"

--- a/client/src/components/CityPopup/Mobile/MobileDetailsList.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileDetailsList.tsx
@@ -1,0 +1,43 @@
+import type { RibbonStat } from '@/types/cityPopupTypes';
+import { CITY1_PRIMARY_COLOR, CITY2_PRIMARY_COLOR } from '@/const';
+
+interface MobileDetailsListProps {
+  stats: ReadonlyArray<RibbonStat>;
+  hasComparison: boolean;
+}
+
+const MobileDetailsList = ({ stats, hasComparison }: MobileDetailsListProps) => {
+  return (
+    <div
+      data-testid="mobile-details-list"
+      className="flex flex-col gap-2 overflow-y-auto"
+    >
+      {stats.map((s) => (
+        <div
+          key={s.label}
+          className="px-3 py-2.5 rounded bg-[var(--mantine-color-default-hover)] border border-[var(--mantine-color-default-border)]"
+        >
+          <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--mantine-color-dimmed)] font-mono">
+            {s.label}
+          </div>
+          <div
+            className="text-[18px] font-bold tabular-nums mt-0.5"
+            style={{ color: CITY1_PRIMARY_COLOR }}
+          >
+            {s.v1}
+          </div>
+          {hasComparison && (
+            <div
+              className="text-[14px] font-semibold tabular-nums mt-0.5"
+              style={{ color: CITY2_PRIMARY_COLOR }}
+            >
+              {s.v2}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MobileDetailsList;

--- a/client/src/components/CityPopup/Mobile/MobileTabBar.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileTabBar.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import {
+  IconDroplet,
+  IconLayoutList,
+  IconSun,
+  IconTemperature,
+} from '@tabler/icons-react';
+import { MobileTab } from '@/types/mobileTabType';
+import {
+  CITY1_PRIMARY_COLOR,
+  MOBILE_DRAWER_TAB_BAR_PX,
+  TOGGLE_ICON_SIZE,
+} from '@/const';
+
+interface MobileTabBarProps {
+  tab: MobileTab;
+  onTab: (next: MobileTab) => void;
+  availableTabs?: ReadonlyArray<MobileTab>;
+}
+
+interface TabItem {
+  id: MobileTab;
+  label: string;
+  icon: ReactNode;
+}
+
+const TABS: ReadonlyArray<TabItem> = [
+  {
+    id: MobileTab.Temperature,
+    label: 'Temp',
+    icon: <IconTemperature size={TOGGLE_ICON_SIZE} />,
+  },
+  {
+    id: MobileTab.Sunshine,
+    label: 'Sun',
+    icon: <IconSun size={TOGGLE_ICON_SIZE} />,
+  },
+  {
+    id: MobileTab.Precip,
+    label: 'Precip',
+    icon: <IconDroplet size={TOGGLE_ICON_SIZE} />,
+  },
+  {
+    id: MobileTab.Details,
+    label: 'Details',
+    icon: <IconLayoutList size={TOGGLE_ICON_SIZE} />,
+  },
+];
+
+const MobileTabBar = ({ tab, onTab, availableTabs }: MobileTabBarProps) => {
+  const visible = availableTabs
+    ? TABS.filter((t) => availableTabs.includes(t.id))
+    : TABS;
+
+  return (
+    <div
+      data-testid="mobile-tab-bar"
+      className="sticky bottom-0 flex items-stretch border-t border-[var(--mantine-color-default-border)] bg-[var(--mantine-color-body)]"
+      style={{ height: MOBILE_DRAWER_TAB_BAR_PX }}
+    >
+      {visible.map((t) => {
+        const active = t.id === tab;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => onTab(t.id)}
+            aria-pressed={active}
+            aria-label={t.label}
+            className="flex-1 flex flex-col items-center justify-center gap-0.5 cursor-pointer transition-colors"
+            style={{
+              borderTop: `2px solid ${active ? CITY1_PRIMARY_COLOR : 'transparent'}`,
+              color: active
+                ? CITY1_PRIMARY_COLOR
+                : 'var(--mantine-color-dimmed)',
+            }}
+          >
+            {t.icon}
+            <span className="text-[10px] font-semibold tracking-wide">
+              {t.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MobileTabBar;

--- a/client/src/components/CityPopup/Mobile/mobileDrawerHelpers.ts
+++ b/client/src/components/CityPopup/Mobile/mobileDrawerHelpers.ts
@@ -1,0 +1,18 @@
+import { DataType } from '@/types/mapTypes';
+import { MobileTab } from '@/types/mobileTabType';
+
+export const dataTypeToMobileTab = (d: DataType): MobileTab => {
+  if (d === DataType.Sunshine) return MobileTab.Sunshine;
+  if (d === DataType.Precip) return MobileTab.Precip;
+  return MobileTab.Temperature;
+};
+
+export const isChartTab = (
+  t: MobileTab
+): t is Exclude<MobileTab, MobileTab.Details> => t !== MobileTab.Details;
+
+export const mobileTabToDataType = (t: MobileTab): DataType => {
+  if (t === MobileTab.Sunshine) return DataType.Sunshine;
+  if (t === MobileTab.Precip) return DataType.Precip;
+  return DataType.Temperature;
+};

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -20,6 +20,8 @@ import {
   MAP_STYLES,
 } from '@/const';
 import CityPopup from '../CityPopup/CityPopup';
+import MobileCityDrawer from '../CityPopup/Mobile/MobileCityDrawer';
+import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
 import MapTooltip from './MapTooltip';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useWeatherStore } from '@/stores/useWeatherStore';
@@ -70,6 +72,7 @@ const WorldMap = ({
   const [mapOpacity, setMapOpacity] = useState(1);
 
   const colorScheme = useComputedColorScheme('dark');
+  const isMobileOrSmall = useIsMobileOrSmall();
   const isLoadingWeather = useWeatherStore((state) => state.isLoadingWeather);
   const isLoadingSunshine = useSunshineStore(
     (state) => state.isLoadingSunshine
@@ -293,17 +296,28 @@ const WorldMap = ({
               zIndex: 50,
             }}
           >
-            {cityToRender && (
-              <ComponentErrorBoundary componentName="CityPopup">
-                <CityPopup
-                  city={cityToRender}
-                  onClose={handleClosePopup}
-                  selectedMonth={selectedMonth}
-                  selectedDate={selectedDate}
-                  dataType={dataType}
-                />
-              </ComponentErrorBoundary>
-            )}
+            {cityToRender &&
+              (isMobileOrSmall ? (
+                <ComponentErrorBoundary componentName="MobileCityDrawer">
+                  <MobileCityDrawer
+                    city={cityToRender}
+                    onClose={handleClosePopup}
+                    selectedMonth={selectedMonth}
+                    selectedDate={selectedDate}
+                    dataType={dataType}
+                  />
+                </ComponentErrorBoundary>
+              ) : (
+                <ComponentErrorBoundary componentName="CityPopup">
+                  <CityPopup
+                    city={cityToRender}
+                    onClose={handleClosePopup}
+                    selectedMonth={selectedMonth}
+                    selectedDate={selectedDate}
+                    dataType={dataType}
+                  />
+                </ComponentErrorBoundary>
+              ))}
           </div>
         )}
       </Transition>

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -500,3 +500,21 @@ export const MOBILE_SCRUBBER_BOTTOM_PX = 16;
 
 // Desktop top offset for floating chrome elements (legend, loader).
 export const DESKTOP_TOP_OFFSET_PX = 16;
+
+// Mobile city drawer geometry.
+export const MOBILE_DRAWER_HEIGHT_CAP_PX = 380;
+export const MOBILE_DRAWER_HEIGHT_VH = 45;
+export const MOBILE_DRAWER_HEADER_PX = 52;
+export const MOBILE_DRAWER_CHART_MIN_PX = 180;
+export const MOBILE_DRAWER_TAB_BAR_PX = 44;
+export const MOBILE_DRAWER_BOTTOM_PAD_PX = 12;
+export const MOBILE_DRAWER_DRAG_HANDLE_W_PX = 36;
+export const MOBILE_DRAWER_DRAG_HANDLE_H_PX = 4;
+export const MOBILE_DRAWER_RADIUS_PX = 28;
+export const MOBILE_DRAWER_DISMISS_DRAG_FRACTION = 0.4;
+export const MOBILE_DRAWER_DISMISS_VELOCITY_PX_PER_S = 500;
+// Velocity-based dismissal is ignored if the drag duration is shorter than
+// this; real flicks span multiple frames, sub-frame deltas are noise.
+export const MOBILE_DRAWER_DISMISS_VELOCITY_MIN_DT_MS = 80;
+export const MOBILE_DRAWER_DISMISS_ANIM_MS = 200;
+export const MS_PER_SECOND = 1000;

--- a/client/src/pages/map.tsx
+++ b/client/src/pages/map.tsx
@@ -101,6 +101,7 @@ const MapPage: FC = () => {
   const setTemperatureUnit = useAppStore((state) => state.setTemperatureUnit);
   const isGesturing = useAppStore((state) => state.isGesturing);
   const legendVisible = useAppStore((state) => state.legendVisible);
+  const isCityDrawerOpen = useAppStore((state) => state.isCityDrawerOpen);
 
   const isMobileOrSmall = useIsMobileOrSmall();
 
@@ -214,6 +215,7 @@ const MapPage: FC = () => {
           selectedDate={selectedDate}
           onDateChange={handleDateChange}
           isMonthly={isSunshineSelected}
+          hidden={isCityDrawerOpen}
         />
       )}
 

--- a/client/src/stores/useAppStore.ts
+++ b/client/src/stores/useAppStore.ts
@@ -19,12 +19,12 @@ interface AppState {
   setTemperatureUnit: (unit: TemperatureUnit) => void;
   mapViewport: MapViewport | null;
   setMapViewport: (viewport: MapViewport) => void;
-  // True while panning/zooming. Displayed-data writes skip while true so
-  // the gesture isn't blocked by a layer rebuild + transition.
   isGesturing: boolean;
   setIsGesturing: (gesturing: boolean) => void;
   legendVisible: boolean;
   setLegendVisible: (value: boolean) => void;
+  isCityDrawerOpen: boolean;
+  setIsCityDrawerOpen: (value: boolean) => void;
   resetHomeLocation: () => void;
 }
 
@@ -50,6 +50,8 @@ export const useAppStore = create<AppState>()(
       setIsGesturing: (isGesturing) => set({ isGesturing }),
       legendVisible: false,
       setLegendVisible: (legendVisible) => set({ legendVisible }),
+      isCityDrawerOpen: false,
+      setIsCityDrawerOpen: (isCityDrawerOpen) => set({ isCityDrawerOpen }),
       resetHomeLocation: () =>
         set({
           homeLocation: null,

--- a/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import MobileCityDrawer from '@/components/CityPopup/Mobile/MobileCityDrawer';
+import { useAppStore } from '@/stores/useAppStore';
+import { DataType } from '@/types/mapTypes';
+import type { WeatherData } from '@/types/cityWeatherDataType';
+import {
+  MOBILE_DRAWER_DISMISS_DRAG_FRACTION,
+  MOBILE_DRAWER_DRAG_HANDLE_W_PX,
+  MOBILE_DRAWER_DRAG_HANDLE_H_PX,
+} from '@/const';
+
+vi.mock('@/api/dates/useWeatherDataForCity', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/api/dates/useSunshineDataForCity', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/api/dates/useWeeklyWeatherForCity', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/components/CityPopup/DataChartTabs', () => ({
+  default: ({ tab }: { tab: DataType }) => (
+    <div data-testid="data-chart-tabs">tab:{tab}</div>
+  ),
+}));
+
+import useWeatherDataForCity from '@/api/dates/useWeatherDataForCity';
+import useSunshineDataForCity from '@/api/dates/useSunshineDataForCity';
+import useWeeklyWeatherForCity from '@/api/dates/useWeeklyWeatherForCity';
+
+const weatherCity: WeatherData = {
+  cityId: 235,
+  city: 'New York',
+  country: 'United States',
+  state: 'New York',
+  suburb: null,
+  date: '2020-01-15',
+  lat: 40.7128,
+  long: -74.006,
+  population: 8_419_000,
+  precipitation: 10,
+  snowDepth: 5,
+  avgTemperature: 5,
+  maxTemperature: 10,
+  minTemperature: 0,
+  stationName: 'NYC Station',
+  submitterId: null,
+};
+
+describe('MobileCityDrawer', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    useAppStore.setState({ isCityDrawerOpen: false });
+
+    vi.mocked(useWeatherDataForCity).mockReturnValue({
+      weatherData: null,
+      weatherLoading: false,
+      weatherError: false,
+    });
+    vi.mocked(useSunshineDataForCity).mockReturnValue({
+      sunshineData: null,
+      sunshineLoading: false,
+      sunshineError: false,
+    });
+    vi.mocked(useWeeklyWeatherForCity).mockReturnValue({
+      weeklyWeatherData: null,
+      loading: false,
+      error: false,
+    });
+  });
+
+  it('renders the drawer root with mobile-specific test id', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(screen.getByTestId('mobile-city-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-bar')).toBeInTheDocument();
+  });
+
+  it('does NOT render the desktop stat-rail', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(screen.queryByTestId('stat-rail')).toBeNull();
+  });
+
+  it('flips useAppStore.isCityDrawerOpen on mount and back on unmount', () => {
+    const { unmount } = render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(useAppStore.getState().isCityDrawerOpen).toBe(true);
+    unmount();
+    expect(useAppStore.getState().isCityDrawerOpen).toBe(false);
+  });
+
+  it('renders the city name in the header', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(
+      screen.getByText('New York, New York, United States')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the X close button as a11y fallback and calls onClose when tapped', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a "+ Compare" affordance when no comparison city is set', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(screen.getByLabelText('Add comparison city')).toBeInTheDocument();
+  });
+
+  it('renders the drag handle pill at the configured dimensions', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    const region = screen.getByTestId('mobile-drawer-drag-region');
+    const pill = region.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(pill).toBeTruthy();
+    expect(pill.style.width).toBe(`${MOBILE_DRAWER_DRAG_HANDLE_W_PX}px`);
+    expect(pill.style.height).toBe(`${MOBILE_DRAWER_DRAG_HANDLE_H_PX}px`);
+  });
+
+  it('starts on the temperature tab when dataType is Temperature', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(screen.getByText('tab:temperature')).toBeInTheDocument();
+  });
+
+  it('switches to the Details tab and hides the chart when Details is tapped', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(screen.queryByTestId('data-chart-tabs')).toBeNull();
+    expect(screen.getByTestId('mobile-details-list')).toBeInTheDocument();
+  });
+
+  it('renders all five Details cards when Details is active', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(screen.getByText('Sun / yr')).toBeInTheDocument();
+    expect(screen.getByText('Rain / yr')).toBeInTheDocument();
+    expect(screen.getByText("This day's range")).toBeInTheDocument();
+    expect(screen.getByText('From home')).toBeInTheDocument();
+    expect(screen.getByText('Population')).toBeInTheDocument();
+  });
+
+  it('snaps back when drag distance is below the dismiss threshold', () => {
+    const { container } = render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    const drawer = screen.getByTestId('mobile-city-drawer');
+    const region = screen.getByTestId('mobile-drawer-drag-region');
+
+    Object.defineProperty(drawer, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        height: 380,
+        top: 0,
+        bottom: 380,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent.pointerDown(region, { pointerId: 1, clientY: 0 });
+    fireEvent.pointerMove(region, { pointerId: 1, clientY: 50 });
+    expect(drawer.style.transform).toBe('translateY(50px)');
+
+    fireEvent.pointerUp(region, { pointerId: 1, clientY: 50 });
+    expect(drawer.style.transform).toBe('translateY(0)');
+    expect(onClose).not.toHaveBeenCalled();
+
+    expect(container).toBeTruthy();
+  });
+
+  it('dismisses when drag distance exceeds the dismiss fraction threshold', async () => {
+    vi.useFakeTimers();
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    const drawer = screen.getByTestId('mobile-city-drawer');
+    const region = screen.getByTestId('mobile-drawer-drag-region');
+
+    Object.defineProperty(drawer, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        height: 380,
+        top: 0,
+        bottom: 380,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    const beyondThreshold = 380 * MOBILE_DRAWER_DISMISS_DRAG_FRACTION + 20;
+
+    fireEvent.pointerDown(region, { pointerId: 1, clientY: 0 });
+    fireEvent.pointerMove(region, { pointerId: 1, clientY: beyondThreshold });
+    fireEvent.pointerUp(region, { pointerId: 1, clientY: beyondThreshold });
+
+    expect(drawer.style.transform).toBe('translateY(100%)');
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('returns null when no city is provided', () => {
+    const { container } = render(
+      <MobileCityDrawer
+        city={null}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(container.querySelector('[data-testid="mobile-city-drawer"]')).toBeNull();
+  });
+});

--- a/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
@@ -319,7 +319,7 @@ describe('MobileCityDrawer', () => {
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    vi.useRealTimers();
+    // beforeEach restores real timers — no need to restore here
   });
 
   it('returns null when no city is provided', () => {
@@ -333,6 +333,8 @@ describe('MobileCityDrawer', () => {
       />
     );
 
-    expect(container.querySelector('[data-testid="mobile-city-drawer"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="mobile-city-drawer"]')
+    ).toBeNull();
   });
 });

--- a/client/src/tests/components/CityPopup/Mobile/MobileDetailsList.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileDetailsList.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@/test-utils';
+import MobileDetailsList from '@/components/CityPopup/Mobile/MobileDetailsList';
+import type { RibbonStat } from '@/types/cityPopupTypes';
+
+const mockStats: ReadonlyArray<RibbonStat> = [
+  { label: 'Sun / yr', v1: '2200 hrs', v2: '1800 hrs' },
+  { label: 'Rain / yr', v1: '950 mm', v2: '720 mm' },
+  { label: "This day's range", v1: '15 / 25°C', v2: '10 / 20°C' },
+  { label: 'From home', v1: '500 km', v2: '300 km' },
+  { label: 'Population', v1: '8M', v2: '4M' },
+];
+
+describe('MobileDetailsList', () => {
+  it('renders one card per stat (5 cards)', () => {
+    render(<MobileDetailsList stats={mockStats} hasComparison />);
+    const list = screen.getByTestId('mobile-details-list');
+    expect(list.children).toHaveLength(5);
+  });
+
+  it('renders each stat label, v1 and v2 when hasComparison is true', () => {
+    render(<MobileDetailsList stats={mockStats} hasComparison />);
+
+    expect(screen.getByText('Sun / yr')).toBeInTheDocument();
+    expect(screen.getByText('2200 hrs')).toBeInTheDocument();
+    expect(screen.getByText('1800 hrs')).toBeInTheDocument();
+    expect(screen.getByText("This day's range")).toBeInTheDocument();
+    expect(screen.getByText('15 / 25°C')).toBeInTheDocument();
+  });
+
+  it('omits v2 values when hasComparison is false', () => {
+    render(<MobileDetailsList stats={mockStats} hasComparison={false} />);
+
+    expect(screen.getByText('2200 hrs')).toBeInTheDocument();
+    expect(screen.queryByText('1800 hrs')).toBeNull();
+    expect(screen.queryByText('720 mm')).toBeNull();
+  });
+
+  it('renders an empty list (zero cards) when stats is empty', () => {
+    render(<MobileDetailsList stats={[]} hasComparison />);
+    const list = screen.getByTestId('mobile-details-list');
+    expect(list.children).toHaveLength(0);
+  });
+
+  it('uses the stat label as a stable React key (no key warnings)', () => {
+    render(<MobileDetailsList stats={mockStats} hasComparison />);
+    const list = screen.getByTestId('mobile-details-list');
+    const labels = Array.from(list.children).map(
+      (card) => within(card as HTMLElement).getAllByText(/\w/)[0]?.textContent
+    );
+    expect(labels).toEqual([
+      'Sun / yr',
+      'Rain / yr',
+      "This day's range",
+      'From home',
+      'Population',
+    ]);
+  });
+});

--- a/client/src/tests/components/CityPopup/Mobile/MobileTabBar.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileTabBar.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test-utils';
+import MobileTabBar from '@/components/CityPopup/Mobile/MobileTabBar';
+import { MobileTab } from '@/types/mobileTabType';
+
+describe('MobileTabBar', () => {
+  it('renders all four tabs in order: Temp / Sun / Precip / Details', () => {
+    render(<MobileTabBar tab={MobileTab.Temperature} onTab={vi.fn()} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.map((b) => b.getAttribute('aria-label'))).toEqual([
+      'Temp',
+      'Sun',
+      'Precip',
+      'Details',
+    ]);
+  });
+
+  it('marks the active tab with aria-pressed=true and others false', () => {
+    render(<MobileTabBar tab={MobileTab.Details} onTab={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Temp' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByRole('button', { name: 'Details' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('calls onTab with the clicked tab id', () => {
+    const onTab = vi.fn();
+    render(<MobileTabBar tab={MobileTab.Temperature} onTab={onTab} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+    expect(onTab).toHaveBeenCalledTimes(1);
+    expect(onTab).toHaveBeenCalledWith(MobileTab.Details);
+  });
+
+  it('hides tabs not present in availableTabs', () => {
+    render(
+      <MobileTabBar
+        tab={MobileTab.Temperature}
+        onTab={vi.fn()}
+        availableTabs={[
+          MobileTab.Temperature,
+          MobileTab.Precip,
+          MobileTab.Details,
+        ]}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Sun' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Temp' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Precip' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+  });
+
+  it('anchors the bar at the bottom with sticky positioning', () => {
+    render(<MobileTabBar tab={MobileTab.Temperature} onTab={vi.fn()} />);
+    const bar = screen.getByTestId('mobile-tab-bar');
+    expect(bar.className).toContain('sticky');
+    expect(bar.className).toContain('bottom-0');
+  });
+});

--- a/client/src/types/mobileTabType.ts
+++ b/client/src/types/mobileTabType.ts
@@ -1,0 +1,6 @@
+export enum MobileTab {
+  Temperature = 'temperature',
+  Sunshine = 'sunshine',
+  Precip = 'precip',
+  Details = 'details',
+}


### PR DESCRIPTION
## Summary

Task 6 of the mobile-layout plan ([2026-05-09-mobile-layout-climate-compare.md](docs/superpowers/plans/2026-05-09-mobile-layout-climate-compare.md)). PR 3 of 4 — opens the door for Task 7/8 polish before adding the compare flow in PR 4.

- **`MobileCityDrawer`** — content-sized (`min(45vh, 380px)`) fixed-position panel that swaps in for `CityPopup` inside the existing `<Transition selectedCity>` block in `WorldMap.tsx`. Reuses every CityPopup data hook, `useRibbonStats`, `TodayReadout`, `DataChartTabs`, and `CityNameRow` unchanged. Drag-to-dismiss via pointer events: distance threshold (>40% of drawer height) OR velocity threshold (>500px/s, gated by an 80ms minimum drag duration to ignore synthetic-event noise).
- **`MobileTabBar`** + **`MobileDetailsList`** — sticky-bottom 4-tab footer (Temp / Sun / Precip / Details, with Sun filterable by `availableTabs`) and the vertical stat-card list shown when Details is active.
- **`isCityDrawerOpen` slice** added to `useAppStore` (transient, NOT persisted). `pages/map.tsx` reads it and passes `hidden={isCityDrawerOpen}` to `MobileDateScrubber`, so the bottom scrubber slides offscreen while the drawer is up (Q1 = Option A).
- **No changes to `WorldMap`'s map subsystem** — only the popup branch inside the Transition. DeckGL gestures continue to work above the drawer (no scrim).

## Test plan
- [x] `npm run test:run` — 871 tests pass (was 848, +23 new for drawer / tab bar / details list)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors (warnings are pre-existing magic-number rules)
- [ ] Manual: at <932px viewport, click marker → drawer renders (not CityPopup); scrubber hidden; X / drag-down >40% closes; tap Details → vertical card list; tap a different marker → drawer's data updates without flicker.
- [ ] Manual: at desktop viewport, behavior unchanged — `CityPopup` still renders.