### PR TITLE
feat(mobile): MobileCompareSheet + recent-cities store

### DIFF
--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/const';
 import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 
 interface ComparisonCitySelectorProps {
   onCitySelect: (city: SearchCitiesResult) => void;
@@ -37,6 +38,7 @@ const ComparisonCitySelector = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { searchCities, isLoading: isSearchLoading } = useCitySearch();
+  const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
 
   useEffect(() => {
     if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
@@ -85,6 +87,7 @@ const ComparisonCitySelector = ({
   }, [opened]);
 
   const handleSelectCity = (city: SearchCitiesResult) => {
+    pushRecentCity(city);
     onCitySelect(city);
     setSearchTerm('');
     setSearchResults([]);

--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/const';
 import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
-import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 
 interface ComparisonCitySelectorProps {
   onCitySelect: (city: SearchCitiesResult) => void;
@@ -30,10 +29,13 @@ const ComparisonCitySelector = ({
   const [searchTerm, setSearchTerm] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { results, isLoading: isSearchLoading } =
-    useCityComparisonSearch(searchTerm);
-  const recentCities = useRecentCitiesStore((s) => s.recentCities);
-  const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
+  const {
+    filteredResults,
+    filteredRecent,
+    isSearching,
+    isLoading: isSearchLoading,
+    pickCity,
+  } = useCityComparisonSearch(searchTerm, excludeCity);
 
   useEffect(() => {
     if (opened) {
@@ -47,7 +49,7 @@ const ComparisonCitySelector = ({
   }, [opened]);
 
   const handleSelectCity = (city: SearchCitiesResult) => {
-    pushRecentCity(city);
+    pickCity(city);
     onCitySelect(city);
     setSearchTerm('');
     setOpened(false);
@@ -67,21 +69,6 @@ const ComparisonCitySelector = ({
       .join(', ');
   }, [selectedCity]);
 
-  const isExcluded = (city: SearchCitiesResult): boolean =>
-    excludeCity != null &&
-    city.name === excludeCity.name &&
-    city.state === excludeCity.state &&
-    city.country === excludeCity.country;
-
-  const filteredResults = excludeCity
-    ? results.filter((city) => !isExcluded(city))
-    : results;
-  const filteredRecent = excludeCity
-    ? recentCities.filter((city) => !isExcluded(city))
-    : recentCities;
-
-  const trimmedSearch = searchTerm.trim();
-  const isSearching = trimmedSearch.length >= MIN_CITY_SEARCH_LENGTH;
   const showSuggested = !isSearching && filteredRecent.length > 0;
   const showSearchPrompt = !isSearching && filteredRecent.length === 0;
 

--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Popover, Loader } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconX } from '@tabler/icons-react';
-import useCitySearch from '@/hooks/useCitySearch';
+import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
 import {
   CITY2_PRIMARY_COLOR,
-  CITY_SEARCH_DEBOUNCE_MS,
   COMPARISON_INPUT_FOCUS_DELAY_MS,
   MIN_CITY_SEARCH_LENGTH,
 } from '@/const';
-import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
+import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
 import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 
@@ -30,50 +28,12 @@ const ComparisonCitySelector = ({
 }: ComparisonCitySelectorProps) => {
   const [opened, setOpened] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
-  const [searchResults, setSearchResults] = useState<SearchCitiesResult[]>([]);
-  const [debouncedSearchTerm] = useDebouncedValue(
-    searchTerm,
-    CITY_SEARCH_DEBOUNCE_MS
-  );
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { searchCities, isLoading: isSearchLoading } = useCitySearch();
+  const { results, isLoading: isSearchLoading } =
+    useCityComparisonSearch(searchTerm);
+  const recentCities = useRecentCitiesStore((s) => s.recentCities);
   const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
-
-  useEffect(() => {
-    if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
-      setSearchResults([]);
-      return undefined;
-    }
-
-    let cancelled = false;
-    searchCities(debouncedSearchTerm)
-      .then((results) => {
-        if (cancelled) return;
-        const filtered = excludeCity
-          ? results.filter(
-              (city) =>
-                !(
-                  city.name === excludeCity.name &&
-                  city.state === excludeCity.state &&
-                  city.country === excludeCity.country
-                )
-            )
-          : results;
-        setSearchResults(filtered);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        parseErrorAndNotify(
-          error,
-          `failed to search cities for "${debouncedSearchTerm}"`
-        );
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [debouncedSearchTerm, searchCities, excludeCity]);
 
   useEffect(() => {
     if (opened) {
@@ -90,7 +50,6 @@ const ComparisonCitySelector = ({
     pushRecentCity(city);
     onCitySelect(city);
     setSearchTerm('');
-    setSearchResults([]);
     setOpened(false);
   };
 
@@ -98,7 +57,6 @@ const ComparisonCitySelector = ({
     e.stopPropagation();
     onCityRemove();
     setSearchTerm('');
-    setSearchResults([]);
     setOpened(false);
   };
 
@@ -108,6 +66,24 @@ const ComparisonCitySelector = ({
       .filter(Boolean)
       .join(', ');
   }, [selectedCity]);
+
+  const isExcluded = (city: SearchCitiesResult): boolean =>
+    excludeCity != null &&
+    city.name === excludeCity.name &&
+    city.state === excludeCity.state &&
+    city.country === excludeCity.country;
+
+  const filteredResults = excludeCity
+    ? results.filter((city) => !isExcluded(city))
+    : results;
+  const filteredRecent = excludeCity
+    ? recentCities.filter((city) => !isExcluded(city))
+    : recentCities;
+
+  const trimmedSearch = searchTerm.trim();
+  const isSearching = trimmedSearch.length >= MIN_CITY_SEARCH_LENGTH;
+  const showSuggested = !isSearching && filteredRecent.length > 0;
+  const showSearchPrompt = !isSearching && filteredRecent.length === 0;
 
   return (
     <Popover
@@ -187,15 +163,12 @@ const ComparisonCitySelector = ({
         onMouseDown={(e) => e.preventDefault()}
       >
         <div className="w-72">
-          {isSearchLoading && (
-            <div className="flex justify-center py-3">
-              <Loader size="xs" />
-            </div>
-          )}
-
-          {!isSearchLoading && searchResults.length > 0 && (
+          {showSuggested && (
             <div className="max-h-60 overflow-y-auto py-1">
-              {searchResults.map((city) => (
+              <div className="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--mantine-color-dimmed)]">
+                Suggested
+              </div>
+              {filteredRecent.map((city) => (
                 <button
                   key={city.id}
                   type="button"
@@ -208,26 +181,50 @@ const ComparisonCitySelector = ({
                   <div className="text-xs text-[var(--mantine-color-dimmed)]">
                     {city.state && `${city.state}, `}
                     {city.country}
-                    {city.population
-                      ? ` • ${(city.population / 1_000_000).toFixed(1)}M`
-                      : ''}
+                    {formatCityPopulationSuffix(city.population)}
                   </div>
                 </button>
               ))}
             </div>
           )}
 
-          {!isSearchLoading &&
-            searchTerm.trim().length >= MIN_CITY_SEARCH_LENGTH &&
-            searchResults.length === 0 && (
-              <div className="text-center py-3 text-xs text-[var(--mantine-color-dimmed)]">
-                No cities found
-              </div>
-            )}
-
-          {searchTerm.trim().length < MIN_CITY_SEARCH_LENGTH && (
+          {showSearchPrompt && (
             <div className="text-center py-3 text-xs text-[var(--mantine-color-dimmed)]">
               Type at least {MIN_CITY_SEARCH_LENGTH} characters
+            </div>
+          )}
+
+          {isSearching && isSearchLoading && (
+            <div className="flex justify-center py-3">
+              <Loader size="xs" />
+            </div>
+          )}
+
+          {isSearching && !isSearchLoading && filteredResults.length > 0 && (
+            <div className="max-h-60 overflow-y-auto py-1">
+              {filteredResults.map((city) => (
+                <button
+                  key={city.id}
+                  type="button"
+                  onClick={() => handleSelectCity(city)}
+                  className="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-[var(--mantine-color-default-border)] cursor-pointer"
+                >
+                  <div className="font-medium text-[var(--mantine-color-text)]">
+                    {city.name}
+                  </div>
+                  <div className="text-xs text-[var(--mantine-color-dimmed)]">
+                    {city.state && `${city.state}, `}
+                    {city.country}
+                    {formatCityPopulationSuffix(city.population)}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {isSearching && !isSearchLoading && filteredResults.length === 0 && (
+            <div className="text-center py-3 text-xs text-[var(--mantine-color-dimmed)]">
+              No cities found
             </div>
           )}
         </div>

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, useMantineColorScheme } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
 import { IconPlus, IconX } from '@tabler/icons-react';
 
@@ -10,6 +11,7 @@ import TodayReadout from '@/components/CityPopup/Ribbon/TodayReadout';
 import DataChartTabs from '@/components/CityPopup/DataChartTabs';
 import MobileTabBar from '@/components/CityPopup/Mobile/MobileTabBar';
 import MobileDetailsList from '@/components/CityPopup/Mobile/MobileDetailsList';
+import MobileCompareSheet from '@/components/CityPopup/Mobile/MobileCompareSheet';
 import { useRibbonStats } from '@/components/CityPopup/hooks/useRibbonStats';
 import { useAppStore } from '@/stores/useAppStore';
 import { toTitleCase } from '@/utils/dataFormatting/toTitleCase';
@@ -68,6 +70,10 @@ const MobileCityDrawer = ({
   const [tab, setTab] = useState<MobileTab>(dataTypeToMobileTab(dataType));
   const [dragOffset, setDragOffset] = useState<number | null>(null);
   const [isDismissing, setIsDismissing] = useState(false);
+  const [
+    compareSheetOpened,
+    { open: openCompareSheet, close: closeCompareSheet },
+  ] = useDisclosure(false);
 
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const dragStartRef = useRef<{ y: number; t: number } | null>(null);
@@ -379,6 +385,7 @@ const MobileCityDrawer = ({
                 color={CITY2_PRIMARY_COLOR}
                 name={comparisonName}
                 lat={comparisonCity?.lat ?? null}
+                onClick={openCompareSheet}
                 actions={
                   <button
                     type="button"
@@ -393,6 +400,7 @@ const MobileCityDrawer = ({
             ) : (
               <button
                 type="button"
+                onClick={openCompareSheet}
                 aria-label="Add comparison city"
                 className="flex items-center gap-2 cursor-pointer text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] transition-colors self-start"
               >
@@ -464,6 +472,17 @@ const MobileCityDrawer = ({
         tab={visibleTab}
         onTab={setTab}
         availableTabs={availableTabs}
+      />
+
+      <MobileCompareSheet
+        opened={compareSheetOpened}
+        onClose={closeCompareSheet}
+        onCitySelect={setComparisonCity}
+        excludeCity={{
+          name: city.city ?? '',
+          state: city.state ?? null,
+          country: city.country ?? null,
+        }}
       />
     </div>
   );

--- a/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
 import { ActionIcon, Loader, Modal, Text, TextInput } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
 
-import useCitySearch from '@/hooks/useCitySearch';
+import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
-import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
-import { CITY_SEARCH_DEBOUNCE_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
+import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
+import { MIN_CITY_SEARCH_LENGTH } from '@/const';
 
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
@@ -25,55 +24,15 @@ const MobileCompareSheet = ({
   excludeCity,
 }: MobileCompareSheetProps) => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [searchResults, setSearchResults] = useState<SearchCitiesResult[]>([]);
-  const [debouncedSearchTerm] = useDebouncedValue(
-    searchTerm,
-    CITY_SEARCH_DEBOUNCE_MS
-  );
 
-  const { searchCities, isLoading: isSearchLoading } = useCitySearch();
+  const { results: searchResults, isLoading: isSearchLoading } =
+    useCityComparisonSearch(searchTerm);
   const recentCities = useRecentCitiesStore((s) => s.recentCities);
   const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
 
   useEffect(() => {
-    if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
-      setSearchResults([]);
-      return undefined;
-    }
-
-    let cancelled = false;
-    searchCities(debouncedSearchTerm)
-      .then((results) => {
-        if (cancelled) return;
-        const filtered = excludeCity
-          ? results.filter(
-              (city) =>
-                !(
-                  city.name === excludeCity.name &&
-                  city.state === excludeCity.state &&
-                  city.country === excludeCity.country
-                )
-            )
-          : results;
-        setSearchResults(filtered);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        parseErrorAndNotify(
-          error,
-          `failed to search cities for "${debouncedSearchTerm}"`
-        );
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [debouncedSearchTerm, searchCities, excludeCity]);
-
-  useEffect(() => {
     if (!opened) {
       setSearchTerm('');
-      setSearchResults([]);
     }
   }, [opened]);
 
@@ -83,12 +42,23 @@ const MobileCompareSheet = ({
     onClose();
   };
 
+  const filteredResults = excludeCity
+    ? searchResults.filter(
+        (city) =>
+          !(
+            city.name === excludeCity.name &&
+            city.state === excludeCity.state &&
+            city.country === excludeCity.country
+          )
+      )
+    : searchResults;
+
   const trimmedSearch = searchTerm.trim();
   const isSearching = trimmedSearch.length >= MIN_CITY_SEARCH_LENGTH;
   const showSuggested = !isSearching && recentCities.length > 0;
   const showEmptyState = !isSearching && recentCities.length === 0;
   const noResults =
-    isSearching && !isSearchLoading && searchResults.length === 0;
+    isSearching && !isSearchLoading && filteredResults.length === 0;
 
   return (
     <Modal
@@ -177,9 +147,9 @@ const MobileCompareSheet = ({
               </div>
             )}
 
-            {!isSearchLoading && searchResults.length > 0 && (
+            {!isSearchLoading && filteredResults.length > 0 && (
               <ul className="list-none p-0 m-0">
-                {searchResults.map((city) => (
+                {filteredResults.map((city) => (
                   <li key={city.id}>
                     <button
                       type="button"
@@ -192,9 +162,7 @@ const MobileCompareSheet = ({
                       <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
                         {city.state ? `${city.state}, ` : ''}
                         {city.country}
-                        {city.population
-                          ? ` • ${(city.population / 1_000_000).toFixed(1)}M`
-                          : ''}
+                        {formatCityPopulationSuffix(city.population)}
                       </span>
                     </button>
                   </li>

--- a/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from 'react';
+import { ActionIcon, Loader, Modal, Text, TextInput } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
+
+import useCitySearch from '@/hooks/useCitySearch';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
+import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
+import { CITY_SEARCH_DEBOUNCE_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
+
+import type { SearchCitiesResult } from '@/types/userLocationType';
+import type { ExcludeCity } from '@/types/cityPopupTypes';
+
+interface MobileCompareSheetProps {
+  opened: boolean;
+  onClose: () => void;
+  onCitySelect: (city: SearchCitiesResult) => void;
+  excludeCity?: ExcludeCity;
+}
+
+const MobileCompareSheet = ({
+  opened,
+  onClose,
+  onCitySelect,
+  excludeCity,
+}: MobileCompareSheetProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchCitiesResult[]>([]);
+  const [debouncedSearchTerm] = useDebouncedValue(
+    searchTerm,
+    CITY_SEARCH_DEBOUNCE_MS
+  );
+
+  const { searchCities, isLoading: isSearchLoading } = useCitySearch();
+  const recentCities = useRecentCitiesStore((s) => s.recentCities);
+  const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
+
+  useEffect(() => {
+    if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
+      setSearchResults([]);
+      return undefined;
+    }
+
+    let cancelled = false;
+    searchCities(debouncedSearchTerm)
+      .then((results) => {
+        if (cancelled) return;
+        const filtered = excludeCity
+          ? results.filter(
+              (city) =>
+                !(
+                  city.name === excludeCity.name &&
+                  city.state === excludeCity.state &&
+                  city.country === excludeCity.country
+                )
+            )
+          : results;
+        setSearchResults(filtered);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        parseErrorAndNotify(
+          error,
+          `failed to search cities for "${debouncedSearchTerm}"`
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedSearchTerm, searchCities, excludeCity]);
+
+  useEffect(() => {
+    if (!opened) {
+      setSearchTerm('');
+      setSearchResults([]);
+    }
+  }, [opened]);
+
+  const handlePick = (city: SearchCitiesResult) => {
+    pushRecentCity(city);
+    onCitySelect(city);
+    onClose();
+  };
+
+  const trimmedSearch = searchTerm.trim();
+  const isSearching = trimmedSearch.length >= MIN_CITY_SEARCH_LENGTH;
+  const showSuggested = !isSearching && recentCities.length > 0;
+  const showEmptyState = !isSearching && recentCities.length === 0;
+  const noResults =
+    isSearching && !isSearchLoading && searchResults.length === 0;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      centered
+      withCloseButton={false}
+      overlayProps={{ opacity: 0.4, blur: 2 }}
+      padding={0}
+      radius="lg"
+      size="md"
+    >
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <Text fw={700} size="md">
+          Compare a city
+        </Text>
+        <ActionIcon
+          onClick={onClose}
+          aria-label="Close compare sheet"
+          variant="subtle"
+          size="md"
+        >
+          <IconX size={18} />
+        </ActionIcon>
+      </div>
+
+      <div className="px-4 pb-2">
+        <TextInput
+          placeholder="Search a city to compare…"
+          leftSection={<IconSearch size={16} />}
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.currentTarget.value)}
+          aria-label="Search a city to compare"
+          autoFocus
+        />
+      </div>
+
+      <div className="px-2 pb-3 max-h-[60vh] overflow-y-auto">
+        {showEmptyState && (
+          <div className="text-center py-6 px-3">
+            <Text size="sm" c="dimmed">
+              Search for a city to compare.
+            </Text>
+          </div>
+        )}
+
+        {showSuggested && (
+          <>
+            <Text size="xs" c="dimmed" px="sm" py="xs" fw={600}>
+              Suggested
+            </Text>
+            <ul className="list-none p-0 m-0">
+              {recentCities.map((city) => (
+                <li key={city.id}>
+                  <button
+                    type="button"
+                    onClick={() => handlePick(city)}
+                    className="w-full flex items-center justify-between text-left px-3 py-3 rounded-md transition-colors hover:bg-[var(--mantine-color-default-hover)] cursor-pointer"
+                  >
+                    <span className="min-w-0 flex-1 mr-2">
+                      <span className="block font-bold text-[15px] text-[var(--mantine-color-text)] truncate">
+                        {city.name}
+                      </span>
+                      <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
+                        {city.state ? `${city.state}, ` : ''}
+                        {city.country}
+                      </span>
+                    </span>
+                    <IconPlus
+                      size={16}
+                      className="opacity-60 shrink-0"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        {isSearching && (
+          <>
+            {isSearchLoading && (
+              <div className="flex justify-center py-4">
+                <Loader size="sm" />
+              </div>
+            )}
+
+            {!isSearchLoading && searchResults.length > 0 && (
+              <ul className="list-none p-0 m-0">
+                {searchResults.map((city) => (
+                  <li key={city.id}>
+                    <button
+                      type="button"
+                      onClick={() => handlePick(city)}
+                      className="w-full text-left px-3 py-3 rounded-md transition-colors hover:bg-[var(--mantine-color-default-hover)] cursor-pointer"
+                    >
+                      <span className="block font-bold text-[15px] text-[var(--mantine-color-text)] truncate">
+                        {city.name}
+                      </span>
+                      <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
+                        {city.state ? `${city.state}, ` : ''}
+                        {city.country}
+                        {city.population
+                          ? ` • ${(city.population / 1_000_000).toFixed(1)}M`
+                          : ''}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {noResults && (
+              <div className="text-center py-4 px-3">
+                <Text size="sm" c="dimmed">
+                  No cities found
+                </Text>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default MobileCompareSheet;

--- a/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
@@ -3,9 +3,7 @@ import { ActionIcon, Loader, Modal, Text, TextInput } from '@mantine/core';
 import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
 
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
-import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
-import { MIN_CITY_SEARCH_LENGTH } from '@/const';
 
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
@@ -25,10 +23,13 @@ const MobileCompareSheet = ({
 }: MobileCompareSheetProps) => {
   const [searchTerm, setSearchTerm] = useState('');
 
-  const { results: searchResults, isLoading: isSearchLoading } =
-    useCityComparisonSearch(searchTerm);
-  const recentCities = useRecentCitiesStore((s) => s.recentCities);
-  const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
+  const {
+    filteredResults,
+    filteredRecent,
+    isSearching,
+    isLoading: isSearchLoading,
+    pickCity,
+  } = useCityComparisonSearch(searchTerm, excludeCity);
 
   useEffect(() => {
     if (!opened) {
@@ -37,26 +38,13 @@ const MobileCompareSheet = ({
   }, [opened]);
 
   const handlePick = (city: SearchCitiesResult) => {
-    pushRecentCity(city);
+    pickCity(city);
     onCitySelect(city);
     onClose();
   };
 
-  const filteredResults = excludeCity
-    ? searchResults.filter(
-        (city) =>
-          !(
-            city.name === excludeCity.name &&
-            city.state === excludeCity.state &&
-            city.country === excludeCity.country
-          )
-      )
-    : searchResults;
-
-  const trimmedSearch = searchTerm.trim();
-  const isSearching = trimmedSearch.length >= MIN_CITY_SEARCH_LENGTH;
-  const showSuggested = !isSearching && recentCities.length > 0;
-  const showEmptyState = !isSearching && recentCities.length === 0;
+  const showSuggested = !isSearching && filteredRecent.length > 0;
+  const showEmptyState = !isSearching && filteredRecent.length === 0;
   const noResults =
     isSearching && !isSearchLoading && filteredResults.length === 0;
 
@@ -111,7 +99,7 @@ const MobileCompareSheet = ({
               Suggested
             </Text>
             <ul className="list-none p-0 m-0">
-              {recentCities.map((city) => (
+              {filteredRecent.map((city) => (
                 <li key={city.id}>
                   <button
                     type="button"
@@ -125,6 +113,7 @@ const MobileCompareSheet = ({
                       <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
                         {city.state ? `${city.state}, ` : ''}
                         {city.country}
+                        {formatCityPopulationSuffix(city.population)}
                       </span>
                     </span>
                     <IconPlus

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -84,9 +84,11 @@ export const MIN_CITY_SEARCH_LENGTH = 2;
 // mid-word typing churn, short enough to feel responsive.
 export const CITY_SEARCH_DEBOUNCE_MS = 300;
 
-// Max entries kept in the persisted recent-cities list (used as the
-// "Suggested" section in MobileCompareSheet). Cap-based, no time TTL.
+// max persisted cities for the "Suggested" list in compare-city UIs
 export const RECENT_CITIES_MAX = 5;
+
+// Divisor used to render city population as "X.XM" in compare/search rows.
+export const POPULATION_MILLION_DIVISOR = 1_000_000;
 
 // map style urls for light and dark themes
 // Carto basemaps - using direct CDN URLs (no proxy needed, CORS-enabled)

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -84,6 +84,10 @@ export const MIN_CITY_SEARCH_LENGTH = 2;
 // mid-word typing churn, short enough to feel responsive.
 export const CITY_SEARCH_DEBOUNCE_MS = 300;
 
+// Max entries kept in the persisted recent-cities list (used as the
+// "Suggested" section in MobileCompareSheet). Cap-based, no time TTL.
+export const RECENT_CITIES_MAX = 5;
+
 // map style urls for light and dark themes
 // Carto basemaps - using direct CDN URLs (no proxy needed, CORS-enabled)
 export const MAP_STYLES = {

--- a/client/src/hooks/useCityComparisonSearch.ts
+++ b/client/src/hooks/useCityComparisonSearch.ts
@@ -1,21 +1,25 @@
 import { useEffect, useState } from 'react';
 import { useDebouncedValue } from '@mantine/hooks';
 import useCitySearch from '@/hooks/useCitySearch';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 import type { SearchCitiesResult } from '@/types/userLocationType';
+import type { ExcludeCity } from '@/types/cityPopupTypes';
 import { CITY_SEARCH_DEBOUNCE_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
 import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
 
 interface UseCityComparisonSearchReturn {
-  results: SearchCitiesResult[];
+  filteredResults: SearchCitiesResult[];
+  filteredRecent: SearchCitiesResult[];
+  isSearching: boolean;
   isLoading: boolean;
+  pickCity: (city: SearchCitiesResult) => void;
 }
 
-// Debounced city search for the compare popover/sheet. Callers apply their
-// own excludeCity filter as derived state — keeping it out of the effect deps
-// avoids the abort-storm where a fresh excludeCity object identity from the
-// parent would re-fire the search and cancel the in-flight request.
+// Debounced city search for compare UIs. excludeCity is applied as derived
+// state, kept out of the effect deps so a fresh object identity from the parent doesn't abort the in-flight request.
 function useCityComparisonSearch(
-  searchTerm: string
+  searchTerm: string,
+  excludeCity?: ExcludeCity
 ): UseCityComparisonSearchReturn {
   const [results, setResults] = useState<SearchCitiesResult[]>([]);
   const [debouncedSearchTerm] = useDebouncedValue(
@@ -23,6 +27,8 @@ function useCityComparisonSearch(
     CITY_SEARCH_DEBOUNCE_MS
   );
   const { searchCities, isLoading } = useCitySearch();
+  const recentCities = useRecentCitiesStore((s) => s.recentCities);
+  const pushRecentCity = useRecentCitiesStore((s) => s.pushRecentCity);
 
   useEffect(() => {
     if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
@@ -49,7 +55,28 @@ function useCityComparisonSearch(
     };
   }, [debouncedSearchTerm, searchCities]);
 
-  return { results, isLoading };
+  const isExcluded = (city: SearchCitiesResult): boolean =>
+    excludeCity != null &&
+    city.name === excludeCity.name &&
+    city.state === excludeCity.state &&
+    city.country === excludeCity.country;
+
+  const filteredResults = excludeCity
+    ? results.filter((city) => !isExcluded(city))
+    : results;
+  const filteredRecent = excludeCity
+    ? recentCities.filter((city) => !isExcluded(city))
+    : recentCities;
+
+  const isSearching = searchTerm.trim().length >= MIN_CITY_SEARCH_LENGTH;
+
+  return {
+    filteredResults,
+    filteredRecent,
+    isSearching,
+    isLoading,
+    pickCity: pushRecentCity,
+  };
 }
 
 export default useCityComparisonSearch;

--- a/client/src/hooks/useCityComparisonSearch.ts
+++ b/client/src/hooks/useCityComparisonSearch.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { useDebouncedValue } from '@mantine/hooks';
+import useCitySearch from '@/hooks/useCitySearch';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+import { CITY_SEARCH_DEBOUNCE_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
+import { parseErrorAndNotify } from '@/utils/errors/parseErrorAndNotify';
+
+interface UseCityComparisonSearchReturn {
+  results: SearchCitiesResult[];
+  isLoading: boolean;
+}
+
+// Debounced city search for the compare popover/sheet. Callers apply their
+// own excludeCity filter as derived state — keeping it out of the effect deps
+// avoids the abort-storm where a fresh excludeCity object identity from the
+// parent would re-fire the search and cancel the in-flight request.
+function useCityComparisonSearch(
+  searchTerm: string
+): UseCityComparisonSearchReturn {
+  const [results, setResults] = useState<SearchCitiesResult[]>([]);
+  const [debouncedSearchTerm] = useDebouncedValue(
+    searchTerm,
+    CITY_SEARCH_DEBOUNCE_MS
+  );
+  const { searchCities, isLoading } = useCitySearch();
+
+  useEffect(() => {
+    if (debouncedSearchTerm.trim().length < MIN_CITY_SEARCH_LENGTH) {
+      setResults([]);
+      return undefined;
+    }
+
+    let cancelled = false;
+    searchCities(debouncedSearchTerm)
+      .then((next) => {
+        if (cancelled) return;
+        setResults(next);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        parseErrorAndNotify(
+          error,
+          `failed to search cities for "${debouncedSearchTerm}"`
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedSearchTerm, searchCities]);
+
+  return { results, isLoading };
+}
+
+export default useCityComparisonSearch;

--- a/client/src/stores/useRecentCitiesStore.ts
+++ b/client/src/stores/useRecentCitiesStore.ts
@@ -20,9 +20,6 @@ export const useRecentCitiesStore = create<RecentCitiesState>()(
           };
         }),
     }),
-    {
-      name: 'recent-cities-storage',
-      partialize: (state) => ({ recentCities: state.recentCities }),
-    }
+    { name: 'recent-cities-storage' }
   )
 );

--- a/client/src/stores/useRecentCitiesStore.ts
+++ b/client/src/stores/useRecentCitiesStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+import { RECENT_CITIES_MAX } from '@/const';
+
+interface RecentCitiesState {
+  recentCities: SearchCitiesResult[];
+  pushRecentCity: (city: SearchCitiesResult) => void;
+}
+
+export const useRecentCitiesStore = create<RecentCitiesState>()(
+  persist(
+    (set) => ({
+      recentCities: [],
+      pushRecentCity: (city) =>
+        set((state) => {
+          const deduped = state.recentCities.filter((c) => c.id !== city.id);
+          return {
+            recentCities: [city, ...deduped].slice(0, RECENT_CITIES_MAX),
+          };
+        }),
+    }),
+    {
+      name: 'recent-cities-storage',
+      partialize: (state) => ({ recentCities: state.recentCities }),
+    }
+  )
+);

--- a/client/src/tests/components/CityPopup/ComparisonCitySelector.test.tsx
+++ b/client/src/tests/components/CityPopup/ComparisonCitySelector.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { render, screen, fireEvent, waitFor } from '@/test-utils';
 import ComparisonCitySelector from '@/components/CityPopup/ComparisonCitySelector';
 import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
+import { MIN_CITY_SEARCH_LENGTH } from '@/const';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 
 const tokyo: SearchCitiesResult = {
@@ -13,6 +14,26 @@ const tokyo: SearchCitiesResult = {
   lat: 35.6762,
   long: 139.6503,
   population: 13_960_000,
+};
+
+const berlin: SearchCitiesResult = {
+  id: 101,
+  name: 'Berlin',
+  country: 'Germany',
+  state: null,
+  lat: 52.52,
+  long: 13.405,
+  population: 3_645_000,
+};
+
+const lisbon: SearchCitiesResult = {
+  id: 102,
+  name: 'Lisbon',
+  country: 'Portugal',
+  state: null,
+  lat: 38.7223,
+  long: -9.1393,
+  population: 545_000,
 };
 
 const searchCitiesMock =
@@ -27,39 +48,148 @@ vi.mock('@/hooks/useCitySearch', () => ({
   }),
 }));
 
-describe('ComparisonCitySelector — recent cities dual-write', () => {
+const openPopover = () =>
+  fireEvent.click(screen.getByLabelText('Add comparison city'));
+
+describe('ComparisonCitySelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
     useRecentCitiesStore.setState({ recentCities: [] });
-    searchCitiesMock.mockResolvedValue([tokyo]);
+    searchCitiesMock.mockResolvedValue([]);
   });
 
-  it('pushes the picked city to useRecentCitiesStore on typed-search select', async () => {
-    const onCitySelect = vi.fn();
-    render(
-      <ComparisonCitySelector
-        onCitySelect={onCitySelect}
-        onCityRemove={vi.fn()}
-        selectedCity={null}
-      />
-    );
+  describe('typed search', () => {
+    it('pushes the picked city to useRecentCitiesStore on typed-search select', async () => {
+      searchCitiesMock.mockResolvedValue([tokyo]);
+      const onCitySelect = vi.fn();
+      render(
+        <ComparisonCitySelector
+          onCitySelect={onCitySelect}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+        />
+      );
 
-    fireEvent.click(screen.getByLabelText('Add comparison city'));
+      openPopover();
 
-    const input = await screen.findByPlaceholderText('Compare a city…');
-    await act(async () => {
-      fireEvent.change(input, { target: { value: 'Tok' } });
+      const input = await screen.findByPlaceholderText('Compare a city…');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'Tok' } });
+      });
+
+      const result = await screen.findByText('Tokyo');
+      await act(async () => {
+        fireEvent.click(result);
+      });
+
+      await waitFor(() => {
+        expect(onCitySelect).toHaveBeenCalledWith(tokyo);
+      });
+      expect(useRecentCitiesStore.getState().recentCities).toEqual([tokyo]);
     });
 
-    const result = await screen.findByText('Tokyo');
-    await act(async () => {
-      fireEvent.click(result);
+    it('filters typed-search results by excludeCity', async () => {
+      searchCitiesMock.mockResolvedValue([tokyo, berlin]);
+      render(
+        <ComparisonCitySelector
+          onCitySelect={vi.fn()}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+          excludeCity={{ name: 'Tokyo', state: null, country: 'Japan' }}
+        />
+      );
+
+      openPopover();
+
+      const input = await screen.findByPlaceholderText('Compare a city…');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'Tok' } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Berlin')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Tokyo')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Suggested section', () => {
+    it(`renders Suggested with recent cities when popover opens with input shorter than ${MIN_CITY_SEARCH_LENGTH} chars`, async () => {
+      useRecentCitiesStore.setState({ recentCities: [tokyo, berlin] });
+      render(
+        <ComparisonCitySelector
+          onCitySelect={vi.fn()}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+        />
+      );
+
+      openPopover();
+
+      expect(await screen.findByText(/Suggested/i)).toBeInTheDocument();
+      expect(screen.getByText('Tokyo')).toBeInTheDocument();
+      expect(screen.getByText('Berlin')).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      expect(onCitySelect).toHaveBeenCalledWith(tokyo);
+    it('renders the existing prompt-to-search copy when store + input are empty (no Suggested header)', async () => {
+      render(
+        <ComparisonCitySelector
+          onCitySelect={vi.fn()}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+        />
+      );
+
+      openPopover();
+
+      expect(
+        await screen.findByText(
+          new RegExp(`Type at least ${MIN_CITY_SEARCH_LENGTH} characters`, 'i')
+        )
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Suggested/i)).not.toBeInTheDocument();
     });
-    expect(useRecentCitiesStore.getState().recentCities).toEqual([tokyo]);
+
+    it('selecting a Suggested city calls onCitySelect and reorders the store newest-first', async () => {
+      useRecentCitiesStore.setState({ recentCities: [tokyo, berlin] });
+      const onCitySelect = vi.fn();
+      render(
+        <ComparisonCitySelector
+          onCitySelect={onCitySelect}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+        />
+      );
+
+      openPopover();
+
+      const berlinRow = await screen.findByText('Berlin');
+      await act(async () => {
+        fireEvent.click(berlinRow);
+      });
+
+      expect(onCitySelect).toHaveBeenCalledWith(berlin);
+      expect(useRecentCitiesStore.getState().recentCities[0]).toEqual(berlin);
+      expect(useRecentCitiesStore.getState().recentCities[1]).toEqual(tokyo);
+    });
+
+    it('filters Suggested cities by excludeCity', async () => {
+      useRecentCitiesStore.setState({ recentCities: [tokyo, berlin, lisbon] });
+      render(
+        <ComparisonCitySelector
+          onCitySelect={vi.fn()}
+          onCityRemove={vi.fn()}
+          selectedCity={null}
+          excludeCity={{ name: 'Berlin', state: null, country: 'Germany' }}
+        />
+      );
+
+      openPopover();
+
+      expect(await screen.findByText('Tokyo')).toBeInTheDocument();
+      expect(screen.getByText('Lisbon')).toBeInTheDocument();
+      expect(screen.queryByText('Berlin')).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/tests/components/CityPopup/ComparisonCitySelector.test.tsx
+++ b/client/src/tests/components/CityPopup/ComparisonCitySelector.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { render, screen, fireEvent, waitFor } from '@/test-utils';
+import ComparisonCitySelector from '@/components/CityPopup/ComparisonCitySelector';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+const tokyo: SearchCitiesResult = {
+  id: 100,
+  name: 'Tokyo',
+  country: 'Japan',
+  state: null,
+  lat: 35.6762,
+  long: 139.6503,
+  population: 13_960_000,
+};
+
+const searchCitiesMock =
+  vi.fn<(term: string) => Promise<SearchCitiesResult[]>>();
+
+vi.mock('@/hooks/useCitySearch', () => ({
+  default: () => ({
+    searchCities: searchCitiesMock,
+    selectCity: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('ComparisonCitySelector — recent cities dual-write', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useRecentCitiesStore.setState({ recentCities: [] });
+    searchCitiesMock.mockResolvedValue([tokyo]);
+  });
+
+  it('pushes the picked city to useRecentCitiesStore on typed-search select', async () => {
+    const onCitySelect = vi.fn();
+    render(
+      <ComparisonCitySelector
+        onCitySelect={onCitySelect}
+        onCityRemove={vi.fn()}
+        selectedCity={null}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Add comparison city'));
+
+    const input = await screen.findByPlaceholderText('Compare a city…');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Tok' } });
+    });
+
+    const result = await screen.findByText('Tokyo');
+    await act(async () => {
+      fireEvent.click(result);
+    });
+
+    await waitFor(() => {
+      expect(onCitySelect).toHaveBeenCalledWith(tokyo);
+    });
+    expect(useRecentCitiesStore.getState().recentCities).toEqual([tokyo]);
+  });
+});

--- a/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileCityDrawer.test.tsx
@@ -29,6 +29,11 @@ vi.mock('@/components/CityPopup/DataChartTabs', () => ({
   ),
 }));
 
+vi.mock('@/components/CityPopup/Mobile/MobileCompareSheet', () => ({
+  default: ({ opened }: { opened: boolean }) =>
+    opened ? <div data-testid="mobile-compare-sheet" /> : null,
+}));
+
 import useWeatherDataForCity from '@/api/dates/useWeatherDataForCity';
 import useSunshineDataForCity from '@/api/dates/useSunshineDataForCity';
 import useWeeklyWeatherForCity from '@/api/dates/useWeeklyWeatherForCity';
@@ -320,6 +325,24 @@ describe('MobileCityDrawer', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
     // beforeEach restores real timers — no need to restore here
+  });
+
+  it('opens MobileCompareSheet when "+ Compare" is tapped', () => {
+    render(
+      <MobileCityDrawer
+        city={weatherCity}
+        onClose={onClose}
+        selectedMonth={1}
+        selectedDate="01-15"
+        dataType={DataType.Temperature}
+      />
+    );
+
+    expect(screen.queryByTestId('mobile-compare-sheet')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Add comparison city'));
+
+    expect(screen.getByTestId('mobile-compare-sheet')).toBeInTheDocument();
   });
 
   it('returns null when no city is provided', () => {

--- a/client/src/tests/components/CityPopup/Mobile/MobileCompareSheet.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileCompareSheet.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { render, screen, fireEvent, waitFor } from '@/test-utils';
+import MobileCompareSheet from '@/components/CityPopup/Mobile/MobileCompareSheet';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+const tokyo: SearchCitiesResult = {
+  id: 100,
+  name: 'Tokyo',
+  country: 'Japan',
+  state: null,
+  lat: 35.6762,
+  long: 139.6503,
+  population: 13_960_000,
+};
+
+const berlin: SearchCitiesResult = {
+  id: 101,
+  name: 'Berlin',
+  country: 'Germany',
+  state: null,
+  lat: 52.52,
+  long: 13.405,
+  population: 3_645_000,
+};
+
+const lisbon: SearchCitiesResult = {
+  id: 102,
+  name: 'Lisbon',
+  country: 'Portugal',
+  state: null,
+  lat: 38.7223,
+  long: -9.1393,
+  population: 545_000,
+};
+
+const searchCitiesMock =
+  vi.fn<(term: string) => Promise<SearchCitiesResult[]>>();
+
+vi.mock('@/hooks/useCitySearch', () => ({
+  default: () => ({
+    searchCities: searchCitiesMock,
+    selectCity: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('MobileCompareSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useRecentCitiesStore.setState({ recentCities: [] });
+    searchCitiesMock.mockResolvedValue([]);
+  });
+
+  it('renders empty-state copy when store + input are empty', () => {
+    render(
+      <MobileCompareSheet opened onClose={vi.fn()} onCitySelect={vi.fn()} />
+    );
+    expect(
+      screen.getByText(/Search for a city to compare/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders Suggested section with recent cities when input is empty', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo, berlin] });
+    render(
+      <MobileCompareSheet opened onClose={vi.fn()} onCitySelect={vi.fn()} />
+    );
+    expect(screen.getByText(/Suggested/i)).toBeInTheDocument();
+    expect(screen.getByText('Tokyo')).toBeInTheDocument();
+    expect(screen.getByText('Berlin')).toBeInTheDocument();
+  });
+
+  it('selects a recent city: calls onCitySelect, pushes to store, closes', async () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo, berlin] });
+    const onCitySelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MobileCompareSheet
+        opened
+        onClose={onClose}
+        onCitySelect={onCitySelect}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Berlin'));
+    });
+
+    expect(onCitySelect).toHaveBeenCalledWith(berlin);
+    expect(onClose).toHaveBeenCalled();
+    expect(useRecentCitiesStore.getState().recentCities[0]).toEqual(berlin);
+  });
+
+  it('typed search renders results and pick triggers select+push+close', async () => {
+    searchCitiesMock.mockResolvedValue([lisbon]);
+    const onCitySelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MobileCompareSheet
+        opened
+        onClose={onClose}
+        onCitySelect={onCitySelect}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/Search a city/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Lis' } });
+    });
+
+    const result = await screen.findByText('Lisbon');
+    await act(async () => {
+      fireEvent.click(result);
+    });
+
+    await waitFor(() => {
+      expect(onCitySelect).toHaveBeenCalledWith(lisbon);
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(useRecentCitiesStore.getState().recentCities[0]).toEqual(lisbon);
+  });
+
+  it('filters search results by excludeCity prop', async () => {
+    searchCitiesMock.mockResolvedValue([tokyo, berlin]);
+    render(
+      <MobileCompareSheet
+        opened
+        onClose={vi.fn()}
+        onCitySelect={vi.fn()}
+        excludeCity={{
+          name: 'Tokyo',
+          state: null,
+          country: 'Japan',
+        }}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/Search a city/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Tok' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Berlin')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Tokyo')).not.toBeInTheDocument();
+  });
+
+  it('X button dismisses without selecting', () => {
+    const onClose = vi.fn();
+    const onCitySelect = vi.fn();
+    render(
+      <MobileCompareSheet
+        opened
+        onClose={onClose}
+        onCitySelect={onCitySelect}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText(/Close compare sheet/i));
+    expect(onClose).toHaveBeenCalled();
+    expect(onCitySelect).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/tests/components/CityPopup/Mobile/MobileCompareSheet.test.tsx
+++ b/client/src/tests/components/CityPopup/Mobile/MobileCompareSheet.test.tsx
@@ -124,6 +124,34 @@ describe('MobileCompareSheet', () => {
     expect(useRecentCitiesStore.getState().recentCities[0]).toEqual(lisbon);
   });
 
+  it('filters Suggested cities by excludeCity prop', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo, berlin, lisbon] });
+    render(
+      <MobileCompareSheet
+        opened
+        onClose={vi.fn()}
+        onCitySelect={vi.fn()}
+        excludeCity={{ name: 'Tokyo', state: null, country: 'Japan' }}
+      />
+    );
+
+    expect(screen.getByText('Berlin')).toBeInTheDocument();
+    expect(screen.getByText('Lisbon')).toBeInTheDocument();
+    expect(screen.queryByText('Tokyo')).not.toBeInTheDocument();
+  });
+
+  it('Suggested rows show the population suffix', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo] });
+    render(
+      <MobileCompareSheet opened onClose={vi.fn()} onCitySelect={vi.fn()} />
+    );
+
+    // formatCityPopulationSuffix renders " • <n>M" — country + suffix sit in
+    // the same subtitle span so we assert the joined textContent.
+    const tokyoRow = screen.getByText('Tokyo').closest('button');
+    expect(tokyoRow).toHaveTextContent(/Japan\s+•\s+\d+(\.\d)?M/);
+  });
+
   it('filters search results by excludeCity prop', async () => {
     searchCitiesMock.mockResolvedValue([tokyo, berlin]);
     render(

--- a/client/src/tests/hooks/useCityComparisonSearch.test.ts
+++ b/client/src/tests/hooks/useCityComparisonSearch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 
 const tokyo: SearchCitiesResult = {
@@ -11,6 +12,16 @@ const tokyo: SearchCitiesResult = {
   lat: 35.6762,
   long: 139.6503,
   population: 13_960_000,
+};
+
+const berlin: SearchCitiesResult = {
+  id: 101,
+  name: 'Berlin',
+  country: 'Germany',
+  state: null,
+  lat: 52.52,
+  long: 13.405,
+  population: 3_645_000,
 };
 
 const lisbon: SearchCitiesResult = {
@@ -38,6 +49,8 @@ vi.mock('@/hooks/useCitySearch', () => ({
 describe('useCityComparisonSearch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    useRecentCitiesStore.setState({ recentCities: [] });
     searchCitiesMock.mockResolvedValue([]);
   });
 
@@ -47,7 +60,8 @@ describe('useCityComparisonSearch', () => {
     // wait past the debounce window to be sure no call was scheduled
     await new Promise((r) => setTimeout(r, 350));
 
-    expect(result.current.results).toEqual([]);
+    expect(result.current.filteredResults).toEqual([]);
+    expect(result.current.isSearching).toBe(false);
     expect(searchCitiesMock).not.toHaveBeenCalled();
   });
 
@@ -59,8 +73,9 @@ describe('useCityComparisonSearch', () => {
       expect(searchCitiesMock).toHaveBeenCalledWith('Tok');
     });
     await waitFor(() => {
-      expect(result.current.results).toEqual([tokyo]);
+      expect(result.current.filteredResults).toEqual([tokyo]);
     });
+    expect(result.current.isSearching).toBe(true);
   });
 
   it('coalesces rapid term changes into a single search for the latest term', async () => {
@@ -107,11 +122,11 @@ describe('useCityComparisonSearch', () => {
     resolveFirst([tokyo]);
 
     await waitFor(() => {
-      expect(result.current.results).toEqual([lisbon]);
+      expect(result.current.filteredResults).toEqual([lisbon]);
     });
     // small grace window to confirm the stale response stayed ignored
     await new Promise((r) => setTimeout(r, 50));
-    expect(result.current.results).toEqual([lisbon]);
+    expect(result.current.filteredResults).toEqual([lisbon]);
   });
 
   it('clears results when the term drops back below MIN length', async () => {
@@ -122,13 +137,63 @@ describe('useCityComparisonSearch', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.results).toEqual([tokyo]);
+      expect(result.current.filteredResults).toEqual([tokyo]);
     });
 
     rerender('');
 
     await waitFor(() => {
-      expect(result.current.results).toEqual([]);
+      expect(result.current.filteredResults).toEqual([]);
     });
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it('filters search results by excludeCity', async () => {
+    searchCitiesMock.mockResolvedValue([tokyo, berlin]);
+    const { result } = renderHook(() =>
+      useCityComparisonSearch('Tok', {
+        name: 'Tokyo',
+        state: null,
+        country: 'Japan',
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.filteredResults).toEqual([berlin]);
+    });
+  });
+
+  it('filters recent cities by excludeCity', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo, berlin, lisbon] });
+    const { result } = renderHook(() =>
+      useCityComparisonSearch('', {
+        name: 'Berlin',
+        state: null,
+        country: 'Germany',
+      })
+    );
+
+    expect(result.current.filteredRecent).toEqual([tokyo, lisbon]);
+  });
+
+  it('exposes recent cities unfiltered when no excludeCity is provided', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo, berlin] });
+    const { result } = renderHook(() => useCityComparisonSearch(''));
+
+    expect(result.current.filteredRecent).toEqual([tokyo, berlin]);
+  });
+
+  it('pickCity pushes the city to the recent-cities store newest-first', () => {
+    useRecentCitiesStore.setState({ recentCities: [tokyo] });
+    const { result } = renderHook(() => useCityComparisonSearch(''));
+
+    act(() => {
+      result.current.pickCity(berlin);
+    });
+
+    expect(useRecentCitiesStore.getState().recentCities).toEqual([
+      berlin,
+      tokyo,
+    ]);
   });
 });

--- a/client/src/tests/hooks/useCityComparisonSearch.test.ts
+++ b/client/src/tests/hooks/useCityComparisonSearch.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+const tokyo: SearchCitiesResult = {
+  id: 100,
+  name: 'Tokyo',
+  country: 'Japan',
+  state: null,
+  lat: 35.6762,
+  long: 139.6503,
+  population: 13_960_000,
+};
+
+const lisbon: SearchCitiesResult = {
+  id: 102,
+  name: 'Lisbon',
+  country: 'Portugal',
+  state: null,
+  lat: 38.7223,
+  long: -9.1393,
+  population: 545_000,
+};
+
+const searchCitiesMock =
+  vi.fn<(term: string) => Promise<SearchCitiesResult[]>>();
+
+vi.mock('@/hooks/useCitySearch', () => ({
+  default: () => ({
+    searchCities: searchCitiesMock,
+    selectCity: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('useCityComparisonSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchCitiesMock.mockResolvedValue([]);
+  });
+
+  it('returns empty results without searching when term is below MIN length', async () => {
+    const { result } = renderHook(() => useCityComparisonSearch('a'));
+
+    // wait past the debounce window to be sure no call was scheduled
+    await new Promise((r) => setTimeout(r, 350));
+
+    expect(result.current.results).toEqual([]);
+    expect(searchCitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('returns search results once the debounced term reaches MIN length', async () => {
+    searchCitiesMock.mockResolvedValue([tokyo]);
+    const { result } = renderHook(() => useCityComparisonSearch('Tok'));
+
+    await waitFor(() => {
+      expect(searchCitiesMock).toHaveBeenCalledWith('Tok');
+    });
+    await waitFor(() => {
+      expect(result.current.results).toEqual([tokyo]);
+    });
+  });
+
+  it('coalesces rapid term changes into a single search for the latest term', async () => {
+    searchCitiesMock.mockResolvedValue([lisbon]);
+    const { rerender } = renderHook(
+      (term: string) => useCityComparisonSearch(term),
+      { initialProps: 'L' }
+    );
+    rerender('Li');
+    rerender('Lis');
+
+    await waitFor(() => {
+      expect(searchCitiesMock).toHaveBeenCalledTimes(1);
+    });
+    expect(searchCitiesMock).toHaveBeenLastCalledWith('Lis');
+  });
+
+  it('out-of-order responses do not clobber the latest results', async () => {
+    let resolveFirst!: (val: SearchCitiesResult[]) => void;
+    const firstPromise = new Promise<SearchCitiesResult[]>((r) => {
+      resolveFirst = r;
+    });
+    searchCitiesMock.mockImplementationOnce(() => firstPromise);
+    searchCitiesMock.mockResolvedValueOnce([lisbon]);
+
+    const { rerender, result } = renderHook(
+      (term: string) => useCityComparisonSearch(term),
+      { initialProps: 'Tok' }
+    );
+
+    // first call kicks off after the debounce
+    await waitFor(() => {
+      expect(searchCitiesMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender('Lis');
+
+    // second call kicks off after the next debounce
+    await waitFor(() => {
+      expect(searchCitiesMock).toHaveBeenCalledTimes(2);
+    });
+
+    // resolve the stale first call AFTER the second was issued — it must be ignored
+    resolveFirst([tokyo]);
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([lisbon]);
+    });
+    // small grace window to confirm the stale response stayed ignored
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.results).toEqual([lisbon]);
+  });
+
+  it('clears results when the term drops back below MIN length', async () => {
+    searchCitiesMock.mockResolvedValue([tokyo]);
+    const { rerender, result } = renderHook(
+      (term: string) => useCityComparisonSearch(term),
+      { initialProps: 'Tok' }
+    );
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([tokyo]);
+    });
+
+    rerender('');
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([]);
+    });
+  });
+});

--- a/client/src/tests/stores/useRecentCitiesStore.test.ts
+++ b/client/src/tests/stores/useRecentCitiesStore.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRecentCitiesStore } from '@/stores/useRecentCitiesStore';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+import { RECENT_CITIES_MAX } from '@/const';
+
+const makeCity = (
+  id: number,
+  overrides?: Partial<SearchCitiesResult>
+): SearchCitiesResult => ({
+  id,
+  name: `City ${id}`,
+  country: 'Country',
+  state: null,
+  lat: id,
+  long: id,
+  population: 1000,
+  ...overrides,
+});
+
+describe('useRecentCitiesStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useRecentCitiesStore.setState({ recentCities: [] });
+  });
+
+  it('initializes with empty recentCities', () => {
+    expect(useRecentCitiesStore.getState().recentCities).toEqual([]);
+  });
+
+  it('pushes a city to the front of the list', () => {
+    const cityA = makeCity(1);
+    useRecentCitiesStore.getState().pushRecentCity(cityA);
+    expect(useRecentCitiesStore.getState().recentCities).toEqual([cityA]);
+  });
+
+  it('orders newest-first when multiple cities are pushed', () => {
+    const cityA = makeCity(1);
+    const cityB = makeCity(2);
+    useRecentCitiesStore.getState().pushRecentCity(cityA);
+    useRecentCitiesStore.getState().pushRecentCity(cityB);
+    expect(useRecentCitiesStore.getState().recentCities).toEqual([
+      cityB,
+      cityA,
+    ]);
+  });
+
+  it('deduplicates by id when pushing an already-present city', () => {
+    const cityA = makeCity(1);
+    const cityB = makeCity(2);
+    useRecentCitiesStore.getState().pushRecentCity(cityA);
+    useRecentCitiesStore.getState().pushRecentCity(cityB);
+    useRecentCitiesStore.getState().pushRecentCity(cityA);
+
+    const { recentCities } = useRecentCitiesStore.getState();
+    expect(recentCities.length).toBe(2);
+    expect(recentCities[0]).toEqual(cityA);
+    expect(recentCities[1]).toEqual(cityB);
+  });
+
+  it(`caps the list length at ${RECENT_CITIES_MAX}`, () => {
+    for (let i = 1; i <= RECENT_CITIES_MAX + 1; i++) {
+      useRecentCitiesStore.getState().pushRecentCity(makeCity(i));
+    }
+    const { recentCities } = useRecentCitiesStore.getState();
+    expect(recentCities.length).toBe(RECENT_CITIES_MAX);
+    expect(recentCities[0]?.id).toBe(RECENT_CITIES_MAX + 1);
+    expect(recentCities[recentCities.length - 1]?.id).toBe(2);
+  });
+
+  it('persists to localStorage under recent-cities-storage', () => {
+    useRecentCitiesStore.getState().pushRecentCity(makeCity(7));
+    const stored = localStorage.getItem('recent-cities-storage');
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored ?? '{}');
+    expect(parsed.state.recentCities).toHaveLength(1);
+    expect(parsed.state.recentCities[0].id).toBe(7);
+  });
+});

--- a/client/src/tests/utils/dataFormatting/formatCityPopulationSuffix.test.ts
+++ b/client/src/tests/utils/dataFormatting/formatCityPopulationSuffix.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
+
+describe('formatCityPopulationSuffix', () => {
+  it('returns empty string when population is null', () => {
+    expect(formatCityPopulationSuffix(null)).toBe('');
+  });
+
+  it('returns empty string when population is undefined', () => {
+    expect(formatCityPopulationSuffix(undefined)).toBe('');
+  });
+
+  it('returns empty string when population is zero', () => {
+    expect(formatCityPopulationSuffix(0)).toBe('');
+  });
+
+  it('formats millions with one decimal and a leading bullet', () => {
+    expect(formatCityPopulationSuffix(13_960_000)).toBe(' • 14.0M');
+  });
+
+  it('formats sub-million populations as fractional millions', () => {
+    expect(formatCityPopulationSuffix(545_000)).toBe(' • 0.5M');
+  });
+});

--- a/client/src/utils/dataFormatting/formatCityPopulationSuffix.ts
+++ b/client/src/utils/dataFormatting/formatCityPopulationSuffix.ts
@@ -1,0 +1,11 @@
+import { POPULATION_MILLION_DIVISOR } from '@/const';
+
+// Compact population suffix (" • 13.9M") for compare/search city rows. Returns
+// an empty string when the value is missing so callers can concatenate without
+// emitting a stray bullet.
+export function formatCityPopulationSuffix(
+  population: number | null | undefined
+): string {
+  if (!population) return '';
+  return ` • ${(population / POPULATION_MILLION_DIVISOR).toFixed(1)}M`;
+}


### PR DESCRIPTION
## Summary

- New persisted Zustand store `useRecentCitiesStore` (cap 5, deduped by id, persisted under `recent-cities-storage`).
- Desktop `ComparisonCitySelector.handleSelectCity` now dual-writes into the recent-cities store so the list is shared across breakpoints.
- New `MobileCompareSheet` (Mantine Modal, 40% scrim) with debounced live search, `excludeCity` filter, and a "Suggested" section backed by the recent-cities store. Empty store + empty input shows empty-state copy.
- `MobileCityDrawer` wires the sheet via `useDisclosure`: opens from `+ Compare` or by tapping an existing comparison-name to swap. Passes the primary city as `excludeCity`.
- Closes Tasks 9-10 of the mobile-layout plan (PR 4 / final slice).

## Test plan

- [x] `npx vitest run` — 885 tests passing (was 871; +14: 6 store + 1 desktop dual-write + 6 sheet + 1 drawer wiring)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (only pre-existing baseline warnings)
- [ ] Manual mobile: tap city → drawer opens → tap `+ Compare` → sheet opens with empty-state → search "Berlin" → pick → drawer header now shows comparison row → tap comparison name → sheet reopens to swap
- [ ] Manual desktop: search "Tokyo" in `ComparisonCitySelector` → pick → confirm `localStorage.recent-cities-storage` populated → reload mobile → "Suggested" list shows Tokyo