### PR TITLE
feat(mobile): city peek-card on map tap

### DIFF
--- a/client/src/components/CityPopup/AddComparisonCityButton.tsx
+++ b/client/src/components/CityPopup/AddComparisonCityButton.tsx
@@ -1,0 +1,39 @@
+import { IconPlus } from '@tabler/icons-react';
+import { CITY2_PRIMARY_COLOR } from '@/const';
+
+interface AddComparisonCityButtonProps {
+  onClick: () => void;
+  variant: 'desktop' | 'mobile';
+}
+
+const AddComparisonCityButton = ({
+  onClick,
+  variant,
+}: AddComparisonCityButtonProps) => {
+  const isDesktop = variant === 'desktop';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Add comparison city"
+      className={`flex items-center gap-2 cursor-pointer text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] transition-colors${isDesktop ? ' min-w-0' : ' self-start'}`}
+    >
+      <span
+        className={`w-2.5 h-2.5 rounded-full opacity-60${isDesktop ? ' shrink-0' : ''}`}
+        style={{ background: CITY2_PRIMARY_COLOR }}
+      />
+      <span
+        className={`font-bold font-[Outfit_Variable]${isDesktop ? ' text-[17px]' : ' text-[15px]'}`}
+      >
+        Compare
+      </span>
+      <IconPlus
+        size={14}
+        className={`opacity-70${isDesktop ? ' shrink-0' : ''}`}
+      />
+    </button>
+  );
+};
+
+export default AddComparisonCityButton;

--- a/client/src/components/CityPopup/AddComparisonCityButton.tsx
+++ b/client/src/components/CityPopup/AddComparisonCityButton.tsx
@@ -1,16 +1,17 @@
 import { IconPlus } from '@tabler/icons-react';
 import { CITY2_PRIMARY_COLOR } from '@/const';
+import { PopupVariant } from '@/types/cityPopupTypes';
 
 interface AddComparisonCityButtonProps {
   onClick: () => void;
-  variant: 'desktop' | 'mobile';
+  variant: PopupVariant;
 }
 
 const AddComparisonCityButton = ({
   onClick,
   variant,
 }: AddComparisonCityButtonProps) => {
-  const isDesktop = variant === 'desktop';
+  const isDesktop = variant === PopupVariant.Desktop;
 
   return (
     <button

--- a/client/src/components/CityPopup/CitySearchResultRow.tsx
+++ b/client/src/components/CityPopup/CitySearchResultRow.tsx
@@ -1,0 +1,60 @@
+import { IconPlus } from '@tabler/icons-react';
+import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+interface CitySearchResultRowProps {
+  city: SearchCitiesResult;
+  onClick: () => void;
+  variant: 'desktop' | 'mobile';
+  showAddIcon?: boolean;
+}
+
+const CitySearchResultRow = ({
+  city,
+  onClick,
+  variant,
+  showAddIcon = false,
+}: CitySearchResultRowProps) => {
+  const subtitle = (
+    <>
+      {city.state ? `${city.state}, ` : ''}
+      {city.country}
+      {formatCityPopulationSuffix(city.population)}
+    </>
+  );
+
+  if (variant === 'mobile') {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`w-full text-left px-3 py-3 rounded-md transition-colors hover:bg-[var(--mantine-color-default-hover)] cursor-pointer${showAddIcon ? ' flex items-center justify-between' : ''}`}
+      >
+        <span className={showAddIcon ? 'min-w-0 flex-1 mr-2' : undefined}>
+          <span className="block font-bold text-[15px] text-[var(--mantine-color-text)] truncate">
+            {city.name}
+          </span>
+          <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
+            {subtitle}
+          </span>
+        </span>
+        {showAddIcon && (
+          <IconPlus size={16} className="opacity-60 shrink-0" aria-hidden="true" />
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-[var(--mantine-color-default-border)] cursor-pointer"
+    >
+      <div className="font-medium text-[var(--mantine-color-text)]">{city.name}</div>
+      <div className="text-xs text-[var(--mantine-color-dimmed)]">{subtitle}</div>
+    </button>
+  );
+};
+
+export default CitySearchResultRow;

--- a/client/src/components/CityPopup/CitySearchResultRow.tsx
+++ b/client/src/components/CityPopup/CitySearchResultRow.tsx
@@ -1,11 +1,12 @@
 import { IconPlus } from '@tabler/icons-react';
 import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
 import type { SearchCitiesResult } from '@/types/userLocationType';
+import { PopupVariant } from '@/types/cityPopupTypes';
 
 interface CitySearchResultRowProps {
   city: SearchCitiesResult;
   onClick: () => void;
-  variant: 'desktop' | 'mobile';
+  variant: PopupVariant;
   showAddIcon?: boolean;
 }
 
@@ -23,7 +24,7 @@ const CitySearchResultRow = ({
     </>
   );
 
-  if (variant === 'mobile') {
+  if (variant === PopupVariant.Mobile) {
     return (
       <button
         type="button"

--- a/client/src/components/CityPopup/CitySearchResultRow.tsx
+++ b/client/src/components/CityPopup/CitySearchResultRow.tsx
@@ -39,7 +39,11 @@ const CitySearchResultRow = ({
           </span>
         </span>
         {showAddIcon && (
-          <IconPlus size={16} className="opacity-60 shrink-0" aria-hidden="true" />
+          <IconPlus
+            size={16}
+            className="opacity-60 shrink-0"
+            aria-hidden="true"
+          />
         )}
       </button>
     );
@@ -51,8 +55,12 @@ const CitySearchResultRow = ({
       onClick={onClick}
       className="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-[var(--mantine-color-default-border)] cursor-pointer"
     >
-      <div className="font-medium text-[var(--mantine-color-text)]">{city.name}</div>
-      <div className="text-xs text-[var(--mantine-color-dimmed)]">{subtitle}</div>
+      <div className="font-medium text-[var(--mantine-color-text)]">
+        {city.name}
+      </div>
+      <div className="text-xs text-[var(--mantine-color-dimmed)]">
+        {subtitle}
+      </div>
     </button>
   );
 };

--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -1,16 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Popover, Loader } from '@mantine/core';
-import { IconPlus, IconX } from '@tabler/icons-react';
+import { IconX } from '@tabler/icons-react';
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
-import {
-  CITY2_PRIMARY_COLOR,
-  COMPARISON_INPUT_FOCUS_DELAY_MS,
-  MIN_CITY_SEARCH_LENGTH,
-} from '@/const';
-import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
+import { CITY2_PRIMARY_COLOR, COMPARISON_INPUT_FOCUS_DELAY_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
+import formatCityFullName from '@/utils/dataFormatting/formatCityFullName';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
+import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
+import AddComparisonCityButton from '@/components/CityPopup/AddComparisonCityButton';
 
 interface ComparisonCitySelectorProps {
   onCitySelect: (city: SearchCitiesResult) => void;
@@ -62,12 +60,7 @@ const ComparisonCitySelector = ({
     setOpened(false);
   };
 
-  const fullName = useMemo(() => {
-    if (!selectedCity) return '';
-    return [selectedCity.name, selectedCity.state, selectedCity.country]
-      .filter(Boolean)
-      .join(', ');
-  }, [selectedCity]);
+  const fullName = selectedCity ? formatCityFullName(selectedCity) : '';
 
   const showSuggested = !isSearching && filteredRecent.length > 0;
   const showSearchPrompt = !isSearching && filteredRecent.length === 0;
@@ -119,21 +112,7 @@ const ComparisonCitySelector = ({
             }
           />
         ) : (
-          <button
-            type="button"
-            onClick={() => setOpened(true)}
-            aria-label="Add comparison city"
-            className="flex items-center gap-2 min-w-0 cursor-pointer text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] transition-colors"
-          >
-            <span
-              className="w-2.5 h-2.5 rounded-full shrink-0 opacity-60"
-              style={{ background: CITY2_PRIMARY_COLOR }}
-            />
-            <span className="text-[17px] font-bold font-[Outfit_Variable]">
-              Compare
-            </span>
-            <IconPlus size={14} className="opacity-70 shrink-0" />
-          </button>
+          <AddComparisonCityButton onClick={() => setOpened(true)} variant="desktop" />
         )}
       </Popover.Target>
 
@@ -156,21 +135,12 @@ const ComparisonCitySelector = ({
                 Suggested
               </div>
               {filteredRecent.map((city) => (
-                <button
+                <CitySearchResultRow
                   key={city.id}
-                  type="button"
+                  city={city}
                   onClick={() => handleSelectCity(city)}
-                  className="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-[var(--mantine-color-default-border)] cursor-pointer"
-                >
-                  <div className="font-medium text-[var(--mantine-color-text)]">
-                    {city.name}
-                  </div>
-                  <div className="text-xs text-[var(--mantine-color-dimmed)]">
-                    {city.state && `${city.state}, `}
-                    {city.country}
-                    {formatCityPopulationSuffix(city.population)}
-                  </div>
-                </button>
+                  variant="desktop"
+                />
               ))}
             </div>
           )}
@@ -190,21 +160,12 @@ const ComparisonCitySelector = ({
           {isSearching && !isSearchLoading && filteredResults.length > 0 && (
             <div className="max-h-60 overflow-y-auto py-1">
               {filteredResults.map((city) => (
-                <button
+                <CitySearchResultRow
                   key={city.id}
-                  type="button"
+                  city={city}
                   onClick={() => handleSelectCity(city)}
-                  className="w-full text-left px-3 py-2 text-sm transition-colors hover:bg-[var(--mantine-color-default-border)] cursor-pointer"
-                >
-                  <div className="font-medium text-[var(--mantine-color-text)]">
-                    {city.name}
-                  </div>
-                  <div className="text-xs text-[var(--mantine-color-dimmed)]">
-                    {city.state && `${city.state}, `}
-                    {city.country}
-                    {formatCityPopulationSuffix(city.population)}
-                  </div>
-                </button>
+                  variant="desktop"
+                />
               ))}
             </div>
           )}

--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -3,7 +3,7 @@ import { Popover, Loader } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import type { SearchCitiesResult } from '@/types/userLocationType';
-import type { ExcludeCity } from '@/types/cityPopupTypes';
+import { PopupVariant, type ExcludeCity } from '@/types/cityPopupTypes';
 import {
   CITY2_PRIMARY_COLOR,
   COMPARISON_INPUT_FOCUS_DELAY_MS,
@@ -118,7 +118,7 @@ const ComparisonCitySelector = ({
         ) : (
           <AddComparisonCityButton
             onClick={() => setOpened(true)}
-            variant="desktop"
+            variant={PopupVariant.Desktop}
           />
         )}
       </Popover.Target>
@@ -146,7 +146,7 @@ const ComparisonCitySelector = ({
                   key={city.id}
                   city={city}
                   onClick={() => handleSelectCity(city)}
-                  variant="desktop"
+                  variant={PopupVariant.Desktop}
                 />
               ))}
             </div>
@@ -171,7 +171,7 @@ const ComparisonCitySelector = ({
                   key={city.id}
                   city={city}
                   onClick={() => handleSelectCity(city)}
-                  variant="desktop"
+                  variant={PopupVariant.Desktop}
                 />
               ))}
             </div>

--- a/client/src/components/CityPopup/ComparisonCitySelector.tsx
+++ b/client/src/components/CityPopup/ComparisonCitySelector.tsx
@@ -4,7 +4,11 @@ import { IconX } from '@tabler/icons-react';
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
-import { CITY2_PRIMARY_COLOR, COMPARISON_INPUT_FOCUS_DELAY_MS, MIN_CITY_SEARCH_LENGTH } from '@/const';
+import {
+  CITY2_PRIMARY_COLOR,
+  COMPARISON_INPUT_FOCUS_DELAY_MS,
+  MIN_CITY_SEARCH_LENGTH,
+} from '@/const';
 import formatCityFullName from '@/utils/dataFormatting/formatCityFullName';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
 import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
@@ -112,7 +116,10 @@ const ComparisonCitySelector = ({
             }
           />
         ) : (
-          <AddComparisonCityButton onClick={() => setOpened(true)} variant="desktop" />
+          <AddComparisonCityButton
+            onClick={() => setOpened(true)}
+            variant="desktop"
+          />
         )}
       </Popover.Target>
 

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -416,9 +416,7 @@ const MobileCityDrawer = ({
         </header>
       </div>
 
-      <main
-        className="flex-1 min-h-0 flex flex-col px-4"
-      >
+      <main className="flex-1 min-h-0 flex flex-col px-4">
         {visibleTab === MobileTab.Details ? (
           <MobileDetailsList stats={stats} hasComparison={!!comparisonCity} />
         ) : (

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -418,45 +418,49 @@ const MobileCityDrawer = ({
 
       <main
         className="flex-1 min-h-0 flex flex-col px-4"
-        style={{ paddingBottom: MOBILE_DRAWER_BOTTOM_PAD_PX }}
       >
         {visibleTab === MobileTab.Details ? (
           <MobileDetailsList stats={stats} hasComparison={!!comparisonCity} />
         ) : (
-          <>
-            <div
-              className="flex-1 min-h-0 overflow-hidden"
-              style={{ minHeight: MOBILE_DRAWER_CHART_MIN_PX }}
-            >
-              <DataChartTabs
-                tab={chartTabForDataChartTabs}
-                displaySunshineData={displaySunshineData}
-                sunshineLoading={sunshineLoading}
-                sunshineError={!!sunshineError}
-                selectedMonth={monthToUse}
-                selectedDate={dateToUse}
-                weeklyWeatherData={weeklyWeatherData}
-                weeklyWeatherLoading={weeklyWeatherLoading}
-                weeklyWeatherError={!!weeklyWeatherError}
-                comparisonSunshineData={comparisonSunshineData}
-                comparisonWeeklyWeatherData={comparisonWeeklyWeatherData}
-              />
-            </div>
-            <div data-testid="mobile-drawer-today-readout" className="shrink-0">
-              <TodayReadout
-                tab={chartTabForDataChartTabs}
-                c1Value={todayPair.c1}
-                c2Value={todayPair.c2}
-                subC1Value={todayPair.subC1 ?? null}
-                subC2Value={todayPair.subC2 ?? null}
-                hasComparison={!!comparisonCity}
-                selectedDate={dateToUse}
-                hover={null}
-              />
-            </div>
-          </>
+          <div
+            className="flex-1 min-h-0 overflow-hidden"
+            style={{ minHeight: MOBILE_DRAWER_CHART_MIN_PX }}
+          >
+            <DataChartTabs
+              tab={chartTabForDataChartTabs}
+              displaySunshineData={displaySunshineData}
+              sunshineLoading={sunshineLoading}
+              sunshineError={!!sunshineError}
+              selectedMonth={monthToUse}
+              selectedDate={dateToUse}
+              weeklyWeatherData={weeklyWeatherData}
+              weeklyWeatherLoading={weeklyWeatherLoading}
+              weeklyWeatherError={!!weeklyWeatherError}
+              comparisonSunshineData={comparisonSunshineData}
+              comparisonWeeklyWeatherData={comparisonWeeklyWeatherData}
+            />
+          </div>
         )}
       </main>
+
+      {visibleTab !== MobileTab.Details && (
+        <div
+          data-testid="mobile-drawer-today-readout"
+          className="shrink-0 px-4"
+          style={{ paddingBottom: MOBILE_DRAWER_BOTTOM_PAD_PX }}
+        >
+          <TodayReadout
+            tab={chartTabForDataChartTabs}
+            c1Value={todayPair.c1}
+            c2Value={todayPair.c2}
+            subC1Value={todayPair.subC1 ?? null}
+            subC2Value={todayPair.subC2 ?? null}
+            hasComparison={!!comparisonCity}
+            selectedDate={dateToUse}
+            hover={null}
+          />
+        </div>
+      )}
 
       <MobileTabBar
         tab={visibleTab}

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -311,7 +311,9 @@ const MobileCityDrawer = ({
     cityAndCountry += `, ${city.country}`;
   }
 
-  const comparisonName = comparisonCity ? formatCityFullName(comparisonCity) : null;
+  const comparisonName = comparisonCity
+    ? formatCityFullName(comparisonCity)
+    : null;
 
   const transformValue = isDismissing
     ? 'translateY(100%)'
@@ -396,7 +398,10 @@ const MobileCityDrawer = ({
                 }
               />
             ) : (
-              <AddComparisonCityButton onClick={openCompareSheet} variant="mobile" />
+              <AddComparisonCityButton
+                onClick={openCompareSheet}
+                variant="mobile"
+              />
             )}
           </div>
           <ActionIcon

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/CityPopup/Mobile/mobileDrawerHelpers';
 import { DataType } from '@/types/mapTypes';
 import { MobileTab } from '@/types/mobileTabType';
+import { PopupVariant } from '@/types/cityPopupTypes';
 import {
   CITY1_PRIMARY_COLOR,
   MONTH_MIDPOINT_DAY,
@@ -400,7 +401,7 @@ const MobileCityDrawer = ({
             ) : (
               <AddComparisonCityButton
                 onClick={openCompareSheet}
-                variant="mobile"
+                variant={PopupVariant.Mobile}
               />
             )}
           </div>
@@ -416,7 +417,7 @@ const MobileCityDrawer = ({
       </div>
 
       <main
-        className="flex-1 min-h-0 flex flex-col px-4 pb-2"
+        className="flex-1 min-h-0 flex flex-col px-4"
         style={{ paddingBottom: MOBILE_DRAWER_BOTTOM_PAD_PX }}
       >
         {visibleTab === MobileTab.Details ? (
@@ -424,7 +425,7 @@ const MobileCityDrawer = ({
         ) : (
           <>
             <div
-              className="flex-1 min-h-0"
+              className="flex-1 min-h-0 overflow-hidden"
               style={{ minHeight: MOBILE_DRAWER_CHART_MIN_PX }}
             >
               <DataChartTabs

--- a/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCityDrawer.tsx
@@ -1,12 +1,14 @@
 import { ActionIcon, useMantineColorScheme } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
-import { IconPlus, IconX } from '@tabler/icons-react';
+import { IconX } from '@tabler/icons-react';
 
 import useWeatherDataForCity from '@/api/dates/useWeatherDataForCity';
 import useSunshineDataForCity from '@/api/dates/useSunshineDataForCity';
 import useWeeklyWeatherForCity from '@/api/dates/useWeeklyWeatherForCity';
 import CityNameRow from '@/components/CityPopup/Ribbon/CityNameRow';
+import AddComparisonCityButton from '@/components/CityPopup/AddComparisonCityButton';
+import formatCityFullName from '@/utils/dataFormatting/formatCityFullName';
 import TodayReadout from '@/components/CityPopup/Ribbon/TodayReadout';
 import DataChartTabs from '@/components/CityPopup/DataChartTabs';
 import MobileTabBar from '@/components/CityPopup/Mobile/MobileTabBar';
@@ -309,11 +311,7 @@ const MobileCityDrawer = ({
     cityAndCountry += `, ${city.country}`;
   }
 
-  const comparisonName = comparisonCity
-    ? [comparisonCity.name, comparisonCity.state, comparisonCity.country]
-        .filter(Boolean)
-        .join(', ')
-    : null;
+  const comparisonName = comparisonCity ? formatCityFullName(comparisonCity) : null;
 
   const transformValue = isDismissing
     ? 'translateY(100%)'
@@ -398,21 +396,7 @@ const MobileCityDrawer = ({
                 }
               />
             ) : (
-              <button
-                type="button"
-                onClick={openCompareSheet}
-                aria-label="Add comparison city"
-                className="flex items-center gap-2 cursor-pointer text-[var(--mantine-color-dimmed)] hover:text-[var(--mantine-color-text)] transition-colors self-start"
-              >
-                <span
-                  className="w-2.5 h-2.5 rounded-full opacity-60"
-                  style={{ background: CITY2_PRIMARY_COLOR }}
-                />
-                <span className="text-[15px] font-bold font-[Outfit_Variable]">
-                  Compare
-                </span>
-                <IconPlus size={14} className="opacity-70" />
-              </button>
+              <AddComparisonCityButton onClick={openCompareSheet} variant="mobile" />
             )}
           </div>
           <ActionIcon
@@ -427,7 +411,7 @@ const MobileCityDrawer = ({
       </div>
 
       <main
-        className="flex-1 min-h-0 flex flex-col px-4"
+        className="flex-1 min-h-0 flex flex-col px-4 pb-2"
         style={{ paddingBottom: MOBILE_DRAWER_BOTTOM_PAD_PX }}
       >
         {visibleTab === MobileTab.Details ? (

--- a/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { ActionIcon, Loader, Modal, Text, TextInput } from '@mantine/core';
-import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
+import { IconSearch, IconX } from '@tabler/icons-react';
 
 import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
-import { formatCityPopulationSuffix } from '@/utils/dataFormatting/formatCityPopulationSuffix';
+import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
 
 import type { SearchCitiesResult } from '@/types/userLocationType';
 import type { ExcludeCity } from '@/types/cityPopupTypes';
@@ -101,27 +101,12 @@ const MobileCompareSheet = ({
             <ul className="list-none p-0 m-0">
               {filteredRecent.map((city) => (
                 <li key={city.id}>
-                  <button
-                    type="button"
+                  <CitySearchResultRow
+                    city={city}
                     onClick={() => handlePick(city)}
-                    className="w-full flex items-center justify-between text-left px-3 py-3 rounded-md transition-colors hover:bg-[var(--mantine-color-default-hover)] cursor-pointer"
-                  >
-                    <span className="min-w-0 flex-1 mr-2">
-                      <span className="block font-bold text-[15px] text-[var(--mantine-color-text)] truncate">
-                        {city.name}
-                      </span>
-                      <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
-                        {city.state ? `${city.state}, ` : ''}
-                        {city.country}
-                        {formatCityPopulationSuffix(city.population)}
-                      </span>
-                    </span>
-                    <IconPlus
-                      size={16}
-                      className="opacity-60 shrink-0"
-                      aria-hidden="true"
-                    />
-                  </button>
+                    variant="mobile"
+                    showAddIcon
+                  />
                 </li>
               ))}
             </ul>
@@ -140,20 +125,11 @@ const MobileCompareSheet = ({
               <ul className="list-none p-0 m-0">
                 {filteredResults.map((city) => (
                   <li key={city.id}>
-                    <button
-                      type="button"
+                    <CitySearchResultRow
+                      city={city}
                       onClick={() => handlePick(city)}
-                      className="w-full text-left px-3 py-3 rounded-md transition-colors hover:bg-[var(--mantine-color-default-hover)] cursor-pointer"
-                    >
-                      <span className="block font-bold text-[15px] text-[var(--mantine-color-text)] truncate">
-                        {city.name}
-                      </span>
-                      <span className="block text-xs text-[var(--mantine-color-dimmed)] truncate">
-                        {city.state ? `${city.state}, ` : ''}
-                        {city.country}
-                        {formatCityPopulationSuffix(city.population)}
-                      </span>
-                    </button>
+                      variant="mobile"
+                    />
                   </li>
                 ))}
               </ul>

--- a/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
+++ b/client/src/components/CityPopup/Mobile/MobileCompareSheet.tsx
@@ -6,7 +6,7 @@ import useCityComparisonSearch from '@/hooks/useCityComparisonSearch';
 import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
 
 import type { SearchCitiesResult } from '@/types/userLocationType';
-import type { ExcludeCity } from '@/types/cityPopupTypes';
+import { PopupVariant, type ExcludeCity } from '@/types/cityPopupTypes';
 
 interface MobileCompareSheetProps {
   opened: boolean;
@@ -104,7 +104,7 @@ const MobileCompareSheet = ({
                   <CitySearchResultRow
                     city={city}
                     onClick={() => handlePick(city)}
-                    variant="mobile"
+                    variant={PopupVariant.Mobile}
                     showAddIcon
                   />
                 </li>
@@ -128,7 +128,7 @@ const MobileCompareSheet = ({
                     <CitySearchResultRow
                       city={city}
                       onClick={() => handlePick(city)}
-                      variant="mobile"
+                      variant={PopupVariant.Mobile}
                     />
                   </li>
                 ))}

--- a/client/src/components/Map/MapTooltip.tsx
+++ b/client/src/components/Map/MapTooltip.tsx
@@ -1,14 +1,17 @@
 import { useRef, useState, useLayoutEffect } from 'react';
-import { useComputedColorScheme } from '@mantine/core';
+import { ActionIcon, useComputedColorScheme } from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
 import { appColors } from '@/theme';
 
 interface MapTooltipProps {
   x: number;
   y: number;
   content: string;
+  /** When provided, renders an inline "+" button that opens the city drawer. */
+  onView?: () => void;
 }
 
-const MapTooltip = ({ x, y, content }: MapTooltipProps) => {
+const MapTooltip = ({ x, y, content, onView }: MapTooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ left: x + 10, top: y + 10 });
 
@@ -37,10 +40,14 @@ const MapTooltip = ({ x, y, content }: MapTooltipProps) => {
     setPosition({ left: newLeft, top: newTop });
   }, [x, y]);
 
+  const interactive = Boolean(onView);
+
   return (
     <div
       ref={tooltipRef}
-      className="pointer-events-none absolute z-50 rounded px-3 py-2 text-sm shadow-lg"
+      className={`absolute z-50 flex items-center gap-2 rounded px-3 py-2 text-sm shadow-lg ${
+        interactive ? 'pointer-events-auto' : 'pointer-events-none'
+      }`}
       style={{
         left: position.left,
         top: position.top,
@@ -49,6 +56,16 @@ const MapTooltip = ({ x, y, content }: MapTooltipProps) => {
       }}
     >
       <div className="whitespace-pre-line">{content}</div>
+      {onView && (
+        <ActionIcon
+          variant="subtle"
+          size="sm"
+          aria-label="Open city details"
+          onClick={onView}
+        >
+          <IconPlus size={16} />
+        </ActionIcon>
+      )}
     </div>
   );
 };

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -150,6 +150,7 @@ const WorldMap = ({
     handleHover,
     handleClick,
     handleClosePopup,
+    openHoveredCity,
   } = useMapInteractions(cities, viewMode, dataType, selectedMonth);
 
   // Memoize controller config to prevent DeckGL from seeing it as a new object on every render
@@ -277,6 +278,9 @@ const WorldMap = ({
           x={hoverInfo.x}
           y={hoverInfo.y}
           content={hoverInfo.content}
+          onView={
+            isMobileOrSmall && hoverInfo.city ? openHoveredCity : undefined
+          }
         />
       )}
 

--- a/client/src/components/Map/WorldMap.tsx
+++ b/client/src/components/Map/WorldMap.tsx
@@ -23,6 +23,7 @@ import CityPopup from '../CityPopup/CityPopup';
 import MobileCityDrawer from '../CityPopup/Mobile/MobileCityDrawer';
 import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
 import MapTooltip from './MapTooltip';
+import { projectCityToScreen } from '@/utils/map/projectCityToScreen';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useWeatherStore } from '@/stores/useWeatherStore';
 import { useSunshineStore } from '@/stores/useSunshineStore';
@@ -64,6 +65,9 @@ const WorldMap = ({
 
   // Track basemap loading state
   const [isBasemapLoaded, setIsBasemapLoaded] = useState(false);
+
+  // Container ref for projecting tooltip lat/long → screen pixels.
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Track whether to show loader (delayed to avoid flash for quick loads)
   const [showLoader, setShowLoader] = useState(false);
@@ -224,8 +228,31 @@ const WorldMap = ({
   // Use the current or last selected city for rendering during transition
   const cityToRender = selectedCity || lastSelectedCityRef.current;
 
+  // For mobile tap-tooltips (hoverInfo.city present), reproject the city's
+  // lat/long to screen pixels on every viewState change so the tooltip stays
+  // glued to the marker while the user pans/zooms. If the city has been
+  // panned off-screen, hide the tooltip. Desktop hover (no city) keeps its
+  // raw cursor-relative coords.
+  const tooltipPosition = useMemo(() => {
+    if (!hoverInfo) return null;
+    const city = hoverInfo.city;
+    if (!city || city.lat == null || city.long == null) {
+      return { x: hoverInfo.x, y: hoverInfo.y };
+    }
+    const container = containerRef.current;
+    if (!container) return { x: hoverInfo.x, y: hoverInfo.y };
+    const { width, height } = container.getBoundingClientRect();
+    return projectCityToScreen({
+      lat: city.lat,
+      long: city.long,
+      viewState,
+      width,
+      height,
+    });
+  }, [hoverInfo, viewState]);
+
   return (
-    <div className="relative h-full w-full">
+    <div ref={containerRef} className="relative h-full w-full">
       <div
         style={{
           opacity: mapOpacity,
@@ -273,10 +300,10 @@ const WorldMap = ({
         )}
       </Transition>
 
-      {hoverInfo && (
+      {hoverInfo && tooltipPosition && (
         <MapTooltip
-          x={hoverInfo.x}
-          y={hoverInfo.y}
+          x={tooltipPosition.x}
+          y={tooltipPosition.y}
           content={hoverInfo.content}
           onView={
             isMobileOrSmall && hoverInfo.city ? openHoveredCity : undefined

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -508,10 +508,10 @@ export const MOBILE_SCRUBBER_BOTTOM_PX = 16;
 export const DESKTOP_TOP_OFFSET_PX = 16;
 
 // Mobile city drawer geometry.
-export const MOBILE_DRAWER_HEIGHT_CAP_PX = 380;
-export const MOBILE_DRAWER_HEIGHT_VH = 45;
+export const MOBILE_DRAWER_HEIGHT_CAP_PX = 420;
+export const MOBILE_DRAWER_HEIGHT_VH = 54;
 export const MOBILE_DRAWER_HEADER_PX = 52;
-export const MOBILE_DRAWER_CHART_MIN_PX = 180;
+export const MOBILE_DRAWER_CHART_MIN_PX = 150;
 export const MOBILE_DRAWER_TAB_BAR_PX = 44;
 export const MOBILE_DRAWER_BOTTOM_PAD_PX = 12;
 export const MOBILE_DRAWER_DRAG_HANDLE_W_PX = 36;

--- a/client/src/hooks/useMapInteractions.ts
+++ b/client/src/hooks/useMapInteractions.ts
@@ -6,9 +6,8 @@ import { useAppStore } from '@/stores/useAppStore';
 import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
 
 /**
- * Manages map interactions: hover tooltips (desktop) and tap-tooltip (mobile).
- * On mobile a marker tap sets hoverInfo with an embedded city so MapTooltip
- * can render a "+" button that promotes the city into the full drawer.
+ * Manages map interactions. On mobile, taps set hoverInfo with an embedded city
+ * so MapTooltip can render a "+" that promotes the city into the full drawer.
  */
 
 interface HoverInfo {
@@ -142,13 +141,11 @@ export const useMapInteractions = (
 
   const handleClick = useCallback(
     (info: PickingInfo) => {
-      // Home-center always opens the drawer directly on both mobile and desktop.
       if (info.layer?.id === 'home-center' && homeCityData) {
         setSelectedCity(homeCityData);
         return;
       }
 
-      // Resolve which city (if any) was hit.
       let hitCity: WeatherDataUnion | null = null;
       if (viewMode === 'markers' && info.object) {
         hitCity = info.object as WeatherDataUnion;
@@ -189,7 +186,6 @@ export const useMapInteractions = (
           city: hitCity,
         });
       } else {
-        // Desktop: open the drawer directly.
         if (hitCity) {
           setSelectedCity(hitCity);
         }

--- a/client/src/hooks/useMapInteractions.ts
+++ b/client/src/hooks/useMapInteractions.ts
@@ -3,16 +3,19 @@ import type { PickingInfo } from '@deck.gl/core';
 import type { DataType, ViewMode, WeatherDataUnion } from '@/types/mapTypes';
 import { getTooltipContent } from '../utils/map/getTooltipContent';
 import { useAppStore } from '@/stores/useAppStore';
+import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
 
 /**
- * hook to manage map interactions including hover tooltips and city selection.
- * handles both marker and heatmap view modes with appropriate interaction logic.
+ * Manages map interactions: hover tooltips (desktop) and tap-tooltip (mobile).
+ * On mobile a marker tap sets hoverInfo with an embedded city so MapTooltip
+ * can render a "+" button that promotes the city into the full drawer.
  */
 
 interface HoverInfo {
   x: number;
   y: number;
   content: string;
+  city?: WeatherDataUnion;
 }
 
 export const useMapInteractions = (
@@ -25,13 +28,19 @@ export const useMapInteractions = (
     null
   );
   const [hoverInfo, setHoverInfo] = useState<HoverInfo | null>(null);
+  const isMobileOrSmall = useIsMobileOrSmall();
   const homeLocation = useAppStore((state) => state.homeLocation);
   const homeCityData = useAppStore((state) => state.homeCityData);
   const temperatureUnit = useAppStore((state) => state.temperatureUnit);
 
-  // Ref for stable callback identity — cities changes on every fetch but callbacks shouldn't recreate
+  // Refs for stable callback identity — these change frequently but DeckGL
+  // shouldn't see a new onClick / onHover on every state flip.
   const citiesRef = useRef(cities);
   citiesRef.current = cities;
+  const isMobileRef = useRef(isMobileOrSmall);
+  isMobileRef.current = isMobileOrSmall;
+  const hoverInfoRef = useRef(hoverInfo);
+  hoverInfoRef.current = hoverInfo;
 
   // Throttle hover updates to reduce re-renders from mouse movement
   const pendingHoverRef = useRef<HoverInfo | null>(null);
@@ -48,6 +57,10 @@ export const useMapInteractions = (
 
   const handleHover = useCallback(
     (info: PickingInfo) => {
+      // On mobile, hover events come from synthetic touch sequences and would
+      // overwrite the tap-set tooltip. The tooltip is tap-driven on mobile.
+      if (isMobileRef.current) return;
+
       let newHoverInfo: HoverInfo | null = null;
 
       // Handle home location hover
@@ -129,33 +142,73 @@ export const useMapInteractions = (
 
   const handleClick = useCallback(
     (info: PickingInfo) => {
-      // check if home location center was clicked
+      // Home-center always opens the drawer directly on both mobile and desktop.
       if (info.layer?.id === 'home-center' && homeCityData) {
         setSelectedCity(homeCityData);
         return;
       }
 
+      // Resolve which city (if any) was hit.
+      let hitCity: WeatherDataUnion | null = null;
       if (viewMode === 'markers' && info.object) {
-        setSelectedCity(info.object as WeatherDataUnion);
+        hitCity = info.object as WeatherDataUnion;
       } else if (viewMode === 'heatmap' && info.coordinate) {
         const [longitude, latitude] = info.coordinate;
-        const city = citiesRef.current.find(
-          (c) =>
-            c.lat !== null &&
-            c.long !== null &&
-            Math.abs(c.lat - latitude) < 0.5 &&
-            Math.abs(c.long - longitude) < 0.5
-        );
-        if (city) {
-          setSelectedCity(city);
+        hitCity =
+          citiesRef.current.find(
+            (c) =>
+              c.lat !== null &&
+              c.long !== null &&
+              Math.abs(c.lat - latitude) < 0.5 &&
+              Math.abs(c.long - longitude) < 0.5
+          ) ?? null;
+      }
+
+      if (isMobileRef.current) {
+        // Mobile: tap shows the tooltip with a "+" button instead of opening
+        // the drawer. Tap-elsewhere or tap-same-marker dismisses it.
+        if (!hitCity) {
+          setHoverInfo(null);
+          return;
+        }
+        if (hoverInfoRef.current?.city?.cityId === hitCity.cityId) {
+          setHoverInfo(null);
+          return;
+        }
+        setHoverInfo({
+          x: info.x,
+          y: info.y,
+          content: getTooltipContent(
+            [hitCity],
+            hitCity.long!,
+            hitCity.lat!,
+            dataType,
+            selectedMonth,
+            temperatureUnit
+          )!,
+          city: hitCity,
+        });
+      } else {
+        // Desktop: open the drawer directly.
+        if (hitCity) {
+          setSelectedCity(hitCity);
         }
       }
     },
-    [viewMode, homeCityData]
+    [viewMode, homeCityData, dataType, selectedMonth, temperatureUnit]
   );
 
   const handleClosePopup = useCallback(() => {
     setSelectedCity(null);
+  }, []);
+
+  // Promotes the city embedded in the current tooltip into the full drawer.
+  const openHoveredCity = useCallback(() => {
+    const city = hoverInfoRef.current?.city;
+    if (city) {
+      setHoverInfo(null);
+      setSelectedCity(city);
+    }
   }, []);
 
   return {
@@ -164,5 +217,6 @@ export const useMapInteractions = (
     handleHover,
     handleClick,
     handleClosePopup,
+    openHoveredCity,
   };
 };

--- a/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
+++ b/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test-utils';
+import AddComparisonCityButton from '@/components/CityPopup/AddComparisonCityButton';
+
+describe('AddComparisonCityButton', () => {
+  it('renders a button with accessible label', () => {
+    render(<AddComparisonCityButton onClick={vi.fn()} variant="desktop" />);
+    expect(
+      screen.getByRole('button', { name: 'Add comparison city' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Compare label', () => {
+    render(<AddComparisonCityButton onClick={vi.fn()} variant="desktop" />);
+    expect(screen.getByText('Compare')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<AddComparisonCityButton onClick={onClick} variant="desktop" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add comparison city' }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders without error for mobile variant', () => {
+    render(<AddComparisonCityButton onClick={vi.fn()} variant="mobile" />);
+    expect(
+      screen.getByRole('button', { name: 'Add comparison city' })
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
+++ b/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
@@ -1,23 +1,24 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test-utils';
 import AddComparisonCityButton from '@/components/CityPopup/AddComparisonCityButton';
+import { PopupVariant } from '@/types/cityPopupTypes';
 
 describe('AddComparisonCityButton', () => {
   it('renders a button with accessible label', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant="desktop" />);
+    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Desktop} />);
     expect(
       screen.getByRole('button', { name: 'Add comparison city' })
     ).toBeInTheDocument();
   });
 
   it('renders the Compare label', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant="desktop" />);
+    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Desktop} />);
     expect(screen.getByText('Compare')).toBeInTheDocument();
   });
 
   it('calls onClick when clicked', () => {
     const onClick = vi.fn();
-    render(<AddComparisonCityButton onClick={onClick} variant="desktop" />);
+    render(<AddComparisonCityButton onClick={onClick} variant={PopupVariant.Desktop} />);
     fireEvent.click(
       screen.getByRole('button', { name: 'Add comparison city' })
     );
@@ -25,7 +26,7 @@ describe('AddComparisonCityButton', () => {
   });
 
   it('renders without error for mobile variant', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant="mobile" />);
+    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Mobile} />);
     expect(
       screen.getByRole('button', { name: 'Add comparison city' })
     ).toBeInTheDocument();

--- a/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
+++ b/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
@@ -18,7 +18,9 @@ describe('AddComparisonCityButton', () => {
   it('calls onClick when clicked', () => {
     const onClick = vi.fn();
     render(<AddComparisonCityButton onClick={onClick} variant="desktop" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Add comparison city' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Add comparison city' })
+    );
     expect(onClick).toHaveBeenCalledOnce();
   });
 

--- a/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
+++ b/client/src/tests/components/CityPopup/AddComparisonCityButton.test.tsx
@@ -5,20 +5,35 @@ import { PopupVariant } from '@/types/cityPopupTypes';
 
 describe('AddComparisonCityButton', () => {
   it('renders a button with accessible label', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Desktop} />);
+    render(
+      <AddComparisonCityButton
+        onClick={vi.fn()}
+        variant={PopupVariant.Desktop}
+      />
+    );
     expect(
       screen.getByRole('button', { name: 'Add comparison city' })
     ).toBeInTheDocument();
   });
 
   it('renders the Compare label', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Desktop} />);
+    render(
+      <AddComparisonCityButton
+        onClick={vi.fn()}
+        variant={PopupVariant.Desktop}
+      />
+    );
     expect(screen.getByText('Compare')).toBeInTheDocument();
   });
 
   it('calls onClick when clicked', () => {
     const onClick = vi.fn();
-    render(<AddComparisonCityButton onClick={onClick} variant={PopupVariant.Desktop} />);
+    render(
+      <AddComparisonCityButton
+        onClick={onClick}
+        variant={PopupVariant.Desktop}
+      />
+    );
     fireEvent.click(
       screen.getByRole('button', { name: 'Add comparison city' })
     );
@@ -26,7 +41,12 @@ describe('AddComparisonCityButton', () => {
   });
 
   it('renders without error for mobile variant', () => {
-    render(<AddComparisonCityButton onClick={vi.fn()} variant={PopupVariant.Mobile} />);
+    render(
+      <AddComparisonCityButton
+        onClick={vi.fn()}
+        variant={PopupVariant.Mobile}
+      />
+    );
     expect(
       screen.getByRole('button', { name: 'Add comparison city' })
     ).toBeInTheDocument();

--- a/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
+++ b/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
@@ -28,7 +28,11 @@ describe('CitySearchResultRow', () => {
   describe('desktop variant', () => {
     it('renders city name and country', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Desktop} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={vi.fn()}
+          variant={PopupVariant.Desktop}
+        />
       );
       expect(screen.getByText('Tokyo')).toBeInTheDocument();
       expect(screen.getByText(/Japan/)).toBeInTheDocument();
@@ -48,7 +52,11 @@ describe('CitySearchResultRow', () => {
     it('calls onClick when clicked', () => {
       const onClick = vi.fn();
       render(
-        <CitySearchResultRow city={tokyo} onClick={onClick} variant={PopupVariant.Desktop} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={onClick}
+          variant={PopupVariant.Desktop}
+        />
       );
       fireEvent.click(screen.getByRole('button'));
       expect(onClick).toHaveBeenCalledOnce();
@@ -56,7 +64,11 @@ describe('CitySearchResultRow', () => {
 
     it('does not render add icon', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Desktop} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={vi.fn()}
+          variant={PopupVariant.Desktop}
+        />
       );
       expect(
         screen.queryByRole('img', { hidden: true })
@@ -67,7 +79,11 @@ describe('CitySearchResultRow', () => {
   describe('mobile variant', () => {
     it('renders city name and country', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Mobile} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={vi.fn()}
+          variant={PopupVariant.Mobile}
+        />
       );
       expect(screen.getByText('Tokyo')).toBeInTheDocument();
       expect(screen.getByText(/Japan/)).toBeInTheDocument();
@@ -75,7 +91,11 @@ describe('CitySearchResultRow', () => {
 
     it('does not render add icon by default', () => {
       const { container } = render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Mobile} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={vi.fn()}
+          variant={PopupVariant.Mobile}
+        />
       );
       expect(container.querySelector('svg')).not.toBeInTheDocument();
     });
@@ -95,7 +115,11 @@ describe('CitySearchResultRow', () => {
     it('calls onClick when clicked', () => {
       const onClick = vi.fn();
       render(
-        <CitySearchResultRow city={tokyo} onClick={onClick} variant={PopupVariant.Mobile} />
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={onClick}
+          variant={PopupVariant.Mobile}
+        />
       );
       fireEvent.click(screen.getByRole('button'));
       expect(onClick).toHaveBeenCalledOnce();

--- a/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
+++ b/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
@@ -35,7 +35,11 @@ describe('CitySearchResultRow', () => {
 
     it('renders state when present', () => {
       render(
-        <CitySearchResultRow city={austin} onClick={vi.fn()} variant="desktop" />
+        <CitySearchResultRow
+          city={austin}
+          onClick={vi.fn()}
+          variant="desktop"
+        />
       );
       expect(screen.getByText(/Texas/)).toBeInTheDocument();
     });
@@ -53,7 +57,9 @@ describe('CitySearchResultRow', () => {
       render(
         <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="desktop" />
       );
-      expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('img', { hidden: true })
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
+++ b/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test-utils';
+import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+const tokyo: SearchCitiesResult = {
+  id: 1,
+  name: 'Tokyo',
+  country: 'Japan',
+  state: null,
+  lat: 35.68,
+  long: 139.69,
+  population: 13_960_000,
+};
+
+const austin: SearchCitiesResult = {
+  id: 2,
+  name: 'Austin',
+  country: 'United States',
+  state: 'Texas',
+  lat: 30.27,
+  long: -97.74,
+  population: 978_908,
+};
+
+describe('CitySearchResultRow', () => {
+  describe('desktop variant', () => {
+    it('renders city name and country', () => {
+      render(
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="desktop" />
+      );
+      expect(screen.getByText('Tokyo')).toBeInTheDocument();
+      expect(screen.getByText(/Japan/)).toBeInTheDocument();
+    });
+
+    it('renders state when present', () => {
+      render(
+        <CitySearchResultRow city={austin} onClick={vi.fn()} variant="desktop" />
+      );
+      expect(screen.getByText(/Texas/)).toBeInTheDocument();
+    });
+
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(
+        <CitySearchResultRow city={tokyo} onClick={onClick} variant="desktop" />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('does not render add icon', () => {
+      render(
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="desktop" />
+      );
+      expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('mobile variant', () => {
+    it('renders city name and country', () => {
+      render(
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="mobile" />
+      );
+      expect(screen.getByText('Tokyo')).toBeInTheDocument();
+      expect(screen.getByText(/Japan/)).toBeInTheDocument();
+    });
+
+    it('does not render add icon by default', () => {
+      const { container } = render(
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="mobile" />
+      );
+      expect(container.querySelector('svg')).not.toBeInTheDocument();
+    });
+
+    it('renders add icon when showAddIcon is true', () => {
+      const { container } = render(
+        <CitySearchResultRow
+          city={tokyo}
+          onClick={vi.fn()}
+          variant="mobile"
+          showAddIcon
+        />
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(
+        <CitySearchResultRow city={tokyo} onClick={onClick} variant="mobile" />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
+++ b/client/src/tests/components/CityPopup/CitySearchResultRow.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@/test-utils';
 import CitySearchResultRow from '@/components/CityPopup/CitySearchResultRow';
 import type { SearchCitiesResult } from '@/types/userLocationType';
+import { PopupVariant } from '@/types/cityPopupTypes';
 
 const tokyo: SearchCitiesResult = {
   id: 1,
@@ -27,7 +28,7 @@ describe('CitySearchResultRow', () => {
   describe('desktop variant', () => {
     it('renders city name and country', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="desktop" />
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Desktop} />
       );
       expect(screen.getByText('Tokyo')).toBeInTheDocument();
       expect(screen.getByText(/Japan/)).toBeInTheDocument();
@@ -38,7 +39,7 @@ describe('CitySearchResultRow', () => {
         <CitySearchResultRow
           city={austin}
           onClick={vi.fn()}
-          variant="desktop"
+          variant={PopupVariant.Desktop}
         />
       );
       expect(screen.getByText(/Texas/)).toBeInTheDocument();
@@ -47,7 +48,7 @@ describe('CitySearchResultRow', () => {
     it('calls onClick when clicked', () => {
       const onClick = vi.fn();
       render(
-        <CitySearchResultRow city={tokyo} onClick={onClick} variant="desktop" />
+        <CitySearchResultRow city={tokyo} onClick={onClick} variant={PopupVariant.Desktop} />
       );
       fireEvent.click(screen.getByRole('button'));
       expect(onClick).toHaveBeenCalledOnce();
@@ -55,7 +56,7 @@ describe('CitySearchResultRow', () => {
 
     it('does not render add icon', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="desktop" />
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Desktop} />
       );
       expect(
         screen.queryByRole('img', { hidden: true })
@@ -66,7 +67,7 @@ describe('CitySearchResultRow', () => {
   describe('mobile variant', () => {
     it('renders city name and country', () => {
       render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="mobile" />
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Mobile} />
       );
       expect(screen.getByText('Tokyo')).toBeInTheDocument();
       expect(screen.getByText(/Japan/)).toBeInTheDocument();
@@ -74,7 +75,7 @@ describe('CitySearchResultRow', () => {
 
     it('does not render add icon by default', () => {
       const { container } = render(
-        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant="mobile" />
+        <CitySearchResultRow city={tokyo} onClick={vi.fn()} variant={PopupVariant.Mobile} />
       );
       expect(container.querySelector('svg')).not.toBeInTheDocument();
     });
@@ -84,7 +85,7 @@ describe('CitySearchResultRow', () => {
         <CitySearchResultRow
           city={tokyo}
           onClick={vi.fn()}
-          variant="mobile"
+          variant={PopupVariant.Mobile}
           showAddIcon
         />
       );
@@ -94,7 +95,7 @@ describe('CitySearchResultRow', () => {
     it('calls onClick when clicked', () => {
       const onClick = vi.fn();
       render(
-        <CitySearchResultRow city={tokyo} onClick={onClick} variant="mobile" />
+        <CitySearchResultRow city={tokyo} onClick={onClick} variant={PopupVariant.Mobile} />
       );
       fireEvent.click(screen.getByRole('button'));
       expect(onClick).toHaveBeenCalledOnce();

--- a/client/src/tests/components/Map/MapTooltip.test.tsx
+++ b/client/src/tests/components/Map/MapTooltip.test.tsx
@@ -22,12 +22,7 @@ describe('MapTooltip', () => {
   describe('with onView (mobile tap)', () => {
     it('renders a + button', () => {
       render(
-        <MapTooltip
-          x={50}
-          y={50}
-          content="Tokyo, Japan"
-          onView={vi.fn()}
-        />
+        <MapTooltip x={50} y={50} content="Tokyo, Japan" onView={vi.fn()} />
       );
       expect(
         screen.getByRole('button', { name: 'Open city details' })

--- a/client/src/tests/components/Map/MapTooltip.test.tsx
+++ b/client/src/tests/components/Map/MapTooltip.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@/test-utils';
+import MapTooltip from '@/components/Map/MapTooltip';
+
+describe('MapTooltip', () => {
+  describe('content', () => {
+    it('renders the content text', () => {
+      render(<MapTooltip x={50} y={50} content="Tokyo, Japan\n26°C" />);
+      expect(screen.getByText(/Tokyo, Japan/)).toBeInTheDocument();
+    });
+  });
+
+  describe('without onView (desktop hover)', () => {
+    it('does not render a + button', () => {
+      render(<MapTooltip x={50} y={50} content="Tokyo, Japan" />);
+      expect(
+        screen.queryByRole('button', { name: 'Open city details' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with onView (mobile tap)', () => {
+    it('renders a + button', () => {
+      render(
+        <MapTooltip
+          x={50}
+          y={50}
+          content="Tokyo, Japan"
+          onView={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole('button', { name: 'Open city details' })
+      ).toBeInTheDocument();
+    });
+
+    it('calls onView when the + button is clicked', () => {
+      const onView = vi.fn();
+      render(
+        <MapTooltip x={50} y={50} content="Tokyo, Japan" onView={onView} />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Open city details' })
+      );
+      expect(onView).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/client/src/tests/hooks/useMapInteractions.test.ts
+++ b/client/src/tests/hooks/useMapInteractions.test.ts
@@ -1,11 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useMapInteractions } from '@/hooks/useMapInteractions';
 import type { WeatherData } from '@/types/cityWeatherDataType';
 import type { PickingInfo } from '@deck.gl/core';
 import { ViewMode, DataType } from '@/types/mapTypes';
 
+vi.mock('@/hooks/useIsMobileOrSmall', () => ({
+  default: vi.fn(() => false),
+}));
+
+import useIsMobileOrSmall from '@/hooks/useIsMobileOrSmall';
+
+// Helper to set the mocked mobile flag.
+const setMobile = (value: boolean) =>
+  vi.mocked(useIsMobileOrSmall).mockReturnValue(value);
+
 describe('useMapInteractions', () => {
+  beforeEach(() => {
+    setMobile(false); // default: desktop
+  });
+
   const createMockCity = (overrides?: Partial<WeatherData>): WeatherData => ({
     cityId: 215,
     city: 'Milan',
@@ -393,6 +407,141 @@ describe('useMapInteractions', () => {
       });
 
       expect(result.current.selectedCity?.city).toBe('Rome');
+    });
+  });
+
+  describe('mobile tap behavior', () => {
+    beforeEach(() => {
+      setMobile(true);
+    });
+
+    it('sets hoverInfo with embedded city on marker tap (does not open drawer)', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+
+      expect(result.current.selectedCity).toBeNull();
+      expect(result.current.hoverInfo?.city).toEqual(city);
+      expect(result.current.hoverInfo?.x).toBe(100);
+      expect(result.current.hoverInfo?.y).toBe(200);
+    });
+
+    it('toggle-dismisses when tapping the same marker twice', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+      expect(result.current.hoverInfo?.city).toEqual(city);
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+      expect(result.current.hoverInfo).toBeNull();
+      expect(result.current.selectedCity).toBeNull();
+    });
+
+    it('swaps to a new city when a different marker is tapped', () => {
+      const milan = createMockCity({ cityId: 1, city: 'Milan' });
+      const rome = createMockCity({
+        cityId: 2,
+        city: 'Rome',
+        lat: 41.9028,
+        long: 12.4964,
+      });
+      const { result } = renderHook(() =>
+        useMapInteractions(
+          [milan, rome],
+          ViewMode.Markers,
+          DataType.Temperature
+        )
+      );
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: milan }));
+      });
+      expect(result.current.hoverInfo?.city?.city).toBe('Milan');
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: rome }));
+      });
+      expect(result.current.hoverInfo?.city?.city).toBe('Rome');
+    });
+
+    it('clears hoverInfo when tapping the map background', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+      expect(result.current.hoverInfo?.city).toEqual(city);
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: null }));
+      });
+      expect(result.current.hoverInfo).toBeNull();
+    });
+
+    it('handleHover is a no-op on mobile (no synthetic hover overwrite)', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      // First, tap to set the tooltip via click.
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+      const tappedHover = result.current.hoverInfo;
+      expect(tappedHover?.city).toEqual(city);
+
+      // A subsequent hover event must NOT alter the tap-set state.
+      act(() => {
+        result.current.handleHover(createMockPickingInfo({ object: null }));
+      });
+      expect(result.current.hoverInfo).toEqual(tappedHover);
+    });
+
+    it('openHoveredCity promotes the peeked city into selectedCity and clears hoverInfo', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      act(() => {
+        result.current.handleClick(createMockPickingInfo({ object: city }));
+      });
+
+      act(() => {
+        result.current.openHoveredCity();
+      });
+
+      expect(result.current.selectedCity).toEqual(city);
+      expect(result.current.hoverInfo).toBeNull();
+    });
+
+    it('openHoveredCity is a no-op when no city is peeked', () => {
+      const city = createMockCity();
+      const { result } = renderHook(() =>
+        useMapInteractions([city], ViewMode.Markers, DataType.Temperature)
+      );
+
+      act(() => {
+        result.current.openHoveredCity();
+      });
+
+      expect(result.current.selectedCity).toBeNull();
     });
   });
 });

--- a/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
+++ b/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
@@ -18,13 +18,9 @@ describe('formatCityFullName', () => {
     ).toBe('Tokyo, Japan');
   });
 
-  it('omits country when null', () => {
+  it('omits country when empty string', () => {
     expect(
-      formatCityFullName({
-        name: 'Austin',
-        state: 'Texas',
-        country: null as unknown as string,
-      })
+      formatCityFullName({ name: 'Austin', state: 'Texas', country: '' })
     ).toBe('Austin, Texas');
   });
 

--- a/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
+++ b/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
@@ -4,7 +4,11 @@ import formatCityFullName from '@/utils/dataFormatting/formatCityFullName';
 describe('formatCityFullName', () => {
   it('joins name, state, and country when all present', () => {
     expect(
-      formatCityFullName({ name: 'Austin', state: 'Texas', country: 'United States' })
+      formatCityFullName({
+        name: 'Austin',
+        state: 'Texas',
+        country: 'United States',
+      })
     ).toBe('Austin, Texas, United States');
   });
 
@@ -16,7 +20,11 @@ describe('formatCityFullName', () => {
 
   it('omits country when null', () => {
     expect(
-      formatCityFullName({ name: 'Austin', state: 'Texas', country: null as unknown as string })
+      formatCityFullName({
+        name: 'Austin',
+        state: 'Texas',
+        country: null as unknown as string,
+      })
     ).toBe('Austin, Texas');
   });
 

--- a/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
+++ b/client/src/tests/utils/dataFormatting/formatCityFullName.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import formatCityFullName from '@/utils/dataFormatting/formatCityFullName';
+
+describe('formatCityFullName', () => {
+  it('joins name, state, and country when all present', () => {
+    expect(
+      formatCityFullName({ name: 'Austin', state: 'Texas', country: 'United States' })
+    ).toBe('Austin, Texas, United States');
+  });
+
+  it('omits state when null', () => {
+    expect(
+      formatCityFullName({ name: 'Tokyo', state: null, country: 'Japan' })
+    ).toBe('Tokyo, Japan');
+  });
+
+  it('omits country when null', () => {
+    expect(
+      formatCityFullName({ name: 'Austin', state: 'Texas', country: null as unknown as string })
+    ).toBe('Austin, Texas');
+  });
+
+  it('returns just the name when state is null and country is empty', () => {
+    expect(
+      formatCityFullName({ name: 'Unknown', state: null, country: '' })
+    ).toBe('Unknown');
+  });
+});

--- a/client/src/tests/utils/map/projectCityToScreen.test.ts
+++ b/client/src/tests/utils/map/projectCityToScreen.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { projectCityToScreen } from '@/utils/map/projectCityToScreen';
+
+const WIDTH = 800;
+const HEIGHT = 600;
+
+describe('projectCityToScreen', () => {
+  it('projects the center of the view to the center of the container', () => {
+    const result = projectCityToScreen({
+      lat: 40,
+      long: -100,
+      viewState: { latitude: 40, longitude: -100, zoom: 3 },
+      width: WIDTH,
+      height: HEIGHT,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.x).toBeCloseTo(WIDTH / 2, 0);
+    expect(result!.y).toBeCloseTo(HEIGHT / 2, 0);
+  });
+
+  it('moves the projected x to the right when the view pans west of the city', () => {
+    const centered = projectCityToScreen({
+      lat: 40,
+      long: -100,
+      viewState: { latitude: 40, longitude: -100, zoom: 3 },
+      width: WIDTH,
+      height: HEIGHT,
+    })!;
+
+    const pannedWest = projectCityToScreen({
+      lat: 40,
+      long: -100,
+      viewState: { latitude: 40, longitude: -110, zoom: 3 },
+      width: WIDTH,
+      height: HEIGHT,
+    })!;
+
+    expect(pannedWest.x).toBeGreaterThan(centered.x);
+  });
+
+  it('returns null when the city is panned off the right edge of the container', () => {
+    const result = projectCityToScreen({
+      lat: 40,
+      long: 100,
+      viewState: { latitude: 40, longitude: -100, zoom: 5 },
+      width: WIDTH,
+      height: HEIGHT,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the city is panned off the top of the container', () => {
+    const result = projectCityToScreen({
+      lat: 80,
+      long: -100,
+      viewState: { latitude: 0, longitude: -100, zoom: 5 },
+      width: WIDTH,
+      height: HEIGHT,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/client/src/types/cityPopupTypes.ts
+++ b/client/src/types/cityPopupTypes.ts
@@ -36,3 +36,8 @@ export interface TodayValuePair {
 }
 
 export type TodayValuesByTab = Readonly<Record<DataType, TodayValuePair>>;
+
+export enum PopupVariant {
+  Desktop = 'desktop',
+  Mobile = 'mobile',
+}

--- a/client/src/utils/dataFormatting/formatCityFullName.ts
+++ b/client/src/utils/dataFormatting/formatCityFullName.ts
@@ -1,0 +1,10 @@
+import type { SearchCitiesResult } from '@/types/userLocationType';
+
+const formatCityFullName = ({
+  name,
+  state,
+  country,
+}: Pick<SearchCitiesResult, 'name' | 'state' | 'country'>): string =>
+  [name, state, country].filter(Boolean).join(', ');
+
+export default formatCityFullName;

--- a/client/src/utils/map/projectCityToScreen.ts
+++ b/client/src/utils/map/projectCityToScreen.ts
@@ -1,0 +1,34 @@
+import type { MapViewState } from '@deck.gl/core';
+import { WebMercatorViewport } from '@deck.gl/core';
+
+interface ProjectCityToScreenArgs {
+  lat: number;
+  long: number;
+  viewState: Pick<MapViewState, 'latitude' | 'longitude' | 'zoom'>;
+  width: number;
+  height: number;
+}
+
+export const projectCityToScreen = ({
+  lat,
+  long,
+  viewState,
+  width,
+  height,
+}: ProjectCityToScreenArgs): { x: number; y: number } | null => {
+  if (width <= 0 || height <= 0) return null;
+
+  const viewport = new WebMercatorViewport({
+    width,
+    height,
+    latitude: viewState.latitude,
+    longitude: viewState.longitude,
+    zoom: viewState.zoom,
+  });
+
+  const [x, y] = viewport.project([long, lat]);
+
+  if (x < 0 || x > width || y < 0 || y > height) return null;
+
+  return { x, y };
+};


### PR DESCRIPTION
## Summary

- On mobile, tapping a map marker now shows an inline peek-card tooltip with a "+" button rather than opening the full city drawer immediately — lets users browse nearby cities before committing to one
- Tapping "+" on the peek-card promotes the city into the full drawer; tapping the same marker again or tapping the map background dismisses it
- Hover events are no-ops on mobile so synthetic touch sequences can't overwrite the tap-set tooltip

## Changes

- `useMapInteractions` — split click behaviour by device: desktop opens drawer directly, mobile sets `hoverInfo` with an embedded city for the peek-card
- `MapTooltip` — optional `onView` prop adds an `ActionIcon` "+" button and makes the tooltip pointer-interactive when provided
- `WorldMap` — passes `openHoveredCity` to `MapTooltip` on mobile only
- `AddComparisonCityButton` — extracted from inline JSX in `ComparisonCitySelector` and `MobileCityDrawer` into a shared component
- `CitySearchResultRow` — extracted duplicated result-row markup from `ComparisonCitySelector` and `MobileCompareSheet` into a shared component
- `formatCityFullName` — extracted repeated name-join logic into a utility
- `PopupVariant` enum added to `cityPopupTypes.ts` (replaces `'desktop' | 'mobile'` string union)
- `MobileCityDrawer` — fixed `TodayReadout` being hidden on small screens (iPhone SE): moved it outside `<main>` so it always renders between the chart and tab bar; bumped `MOBILE_DRAWER_HEIGHT_VH` 45→54 and `MOBILE_DRAWER_HEIGHT_CAP_PX` 380→420; reduced `MOBILE_DRAWER_CHART_MIN_PX` 180→150

## Test plan

- [ ] Tap a map marker on mobile — peek-card tooltip appears with city name and "+" button
- [ ] Tap "+" — drawer opens for that city
- [ ] Tap same marker again — tooltip dismisses
- [ ] Tap map background — tooltip dismisses
- [ ] Tap different marker — tooltip swaps to new city
- [ ] Desktop: clicking a marker still opens the drawer directly (no tooltip step)
- [ ] TodayReadout visible on all chart tabs on iPhone SE
- [ ] "x rainy days" sub-line on precip tab doesn't overlap the chart on iPhone SE
- [ ] Compare flow unaffected on both mobile and desktop